### PR TITLE
[Feature] 예약 API 호출 시 멱등성을 지키기 위한 aop 구현 및 UNIQUE KEY 컬럼 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/global/aop/idempotent/Idempotent.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/idempotent/Idempotent.java
@@ -12,8 +12,12 @@ import java.util.concurrent.TimeUnit;
 public @interface Idempotent {
 
     String key();
+
     String prefix();
+
     long expiration() default 5L;
+
     TimeUnit timeUnit() default TimeUnit.MINUTES;
+
     Class<? extends RuntimeException> exceptionOnDuplicate() default DuplicateRequestException.class;
 }

--- a/src/main/java/com/noljo/nolzo/global/aop/idempotent/Idempotent.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/idempotent/Idempotent.java
@@ -1,0 +1,19 @@
+package com.noljo.nolzo.global.aop.idempotent;
+
+import com.sun.jdi.request.DuplicateRequestException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+
+    String key();
+    String prefix();
+    long expiration() default 5L;
+    TimeUnit timeUnit() default TimeUnit.MINUTES;
+    Class<? extends RuntimeException> exceptionOnDuplicate() default DuplicateRequestException.class;
+}

--- a/src/main/java/com/noljo/nolzo/global/aop/idempotent/Idempotent.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/idempotent/Idempotent.java
@@ -1,6 +1,6 @@
 package com.noljo.nolzo.global.aop.idempotent;
 
-import com.sun.jdi.request.DuplicateRequestException;
+import com.noljo.nolzo.global.error.exception.DuplicateRequestException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/com/noljo/nolzo/global/aop/idempotent/IdempotentAspect.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/idempotent/IdempotentAspect.java
@@ -44,8 +44,14 @@ public class IdempotentAspect {
             );
 
             if (Boolean.FALSE.equals(isSet)) {
+                Class<? extends RuntimeException> exClass = annotation.exceptionOnDuplicate();
                 log.info("멱등성 위반: {}", idempotentKey);
-                throw annotation.exceptionOnDuplicate().getConstructor().newInstance();
+                try {
+                    throw exClass.getConstructor(String.class)
+                            .newInstance("중복 요청입니다. key=" + idempotentKey);
+                } catch (NoSuchMethodException ignore) {
+                    throw exClass.getConstructor().newInstance();
+                }
             }
 
             log.info("멱등성 키 설정 성공: {}", idempotentKey);

--- a/src/main/java/com/noljo/nolzo/global/aop/idempotent/IdempotentAspect.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/idempotent/IdempotentAspect.java
@@ -1,0 +1,69 @@
+package com.noljo.nolzo.global.aop.idempotent;
+
+import com.noljo.nolzo.global.aop.utils.AspectUtils;
+import com.noljo.nolzo.global.error.exception.SeatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class IdempotentAspect {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Around("@annotation(com.noljo.nolzo.global.aop.idempotent.Idempotent)")
+    public Object checkIdempotency(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Idempotent annotation = signature.getMethod().getAnnotation(Idempotent.class);
+
+        String idempotentKey = AspectUtils.parseKey(signature, joinPoint, annotation.key(), annotation.prefix());
+        log.info("멱등성 체크 시작: {}", idempotentKey);
+        return checkAndSet(joinPoint, annotation, idempotentKey);
+    }
+
+    private Object checkAndSet(ProceedingJoinPoint joinPoint, Idempotent annotation, String idempotentKey)
+            throws Throwable {
+        try {
+            log.info("Redis에 키 설정 시도: {}", idempotentKey);
+            Boolean isSet = redisTemplate.opsForValue().setIfAbsent(
+                    idempotentKey,
+                    "1",
+                    annotation.expiration(),
+                    annotation.timeUnit()
+            );
+
+            if (Boolean.FALSE.equals(isSet)) {
+                log.info("멱등성 위반: {}", idempotentKey);
+                throw annotation.exceptionOnDuplicate().getConstructor().newInstance();
+            }
+
+            log.info("멱등성 키 설정 성공: {}", idempotentKey);
+            log.info("메서드 실행 시작: {}", joinPoint.getSignature().getName());
+            Object result = joinPoint.proceed();
+            log.info("메서드 실행 완료: {}", joinPoint.getSignature().getName());
+            return result;
+
+        } catch (SeatException e) {
+            log.info("비즈니스 예외 발생, 멱등성 키 삭제: {}", idempotentKey);
+            redisTemplate.delete(idempotentKey);
+            throw e;
+        } catch (Exception e) {
+            log.error("멱등성 체크 중 오류 발생: {}", e.getMessage(), e);
+            if (e instanceof RuntimeException) {
+                throw e;
+            }
+            throw new RuntimeException("멱등성 체크 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/noljo/nolzo/global/aop/idempotent/filter/CachingRequestFilter.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/idempotent/filter/CachingRequestFilter.java
@@ -1,0 +1,32 @@
+package com.noljo.nolzo.global.aop.idempotent.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+@Order(Integer.MIN_VALUE)
+public class CachingRequestFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        // GET 요청이 아닌 경우에만 ContentCachingRequestWrapper 적용
+        if (!"GET".equalsIgnoreCase(httpServletRequest.getMethod())) {
+            // ContentCachingRequestWrapper로 요청 래핑
+            ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(httpServletRequest);
+
+            filterChain.doFilter(wrappedRequest, response);
+        }
+        // GET 요청인 경우 ContentCachingRequestWrapper 적용하지 않음
+        else {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+}

--- a/src/main/java/com/noljo/nolzo/global/aop/utils/AspectUtils.java
+++ b/src/main/java/com/noljo/nolzo/global/aop/utils/AspectUtils.java
@@ -1,0 +1,32 @@
+package com.noljo.nolzo.global.aop.utils;
+
+import java.util.Optional;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class AspectUtils {
+
+    public static String parseKey(
+            MethodSignature signature,
+            ProceedingJoinPoint proceedingJoinPoint,
+            String keyExpression,
+            String prefix
+    ) {
+        String[] parameterNames = signature.getParameterNames();
+        Object[] args = proceedingJoinPoint.getArgs();
+
+        var parser = new SpelExpressionParser();
+        var context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+        var parsed = parser.parseExpression(keyExpression).getValue(context, Object.class);
+
+        return Optional.ofNullable(parsed)
+                .map(i -> prefix + i)
+                .orElseThrow(() -> new IllegalArgumentException("키는 null이 될 수 없습니다."));
+    }
+}

--- a/src/main/java/com/noljo/nolzo/global/config/RedisConfig.java
+++ b/src/main/java/com/noljo/nolzo/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -21,7 +22,10 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(String.valueOf(port)));
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
     @Bean

--- a/src/main/java/com/noljo/nolzo/global/error/exception/DuplicateRequestException.java
+++ b/src/main/java/com/noljo/nolzo/global/error/exception/DuplicateRequestException.java
@@ -1,0 +1,11 @@
+package com.noljo.nolzo.global.error.exception;
+
+public class DuplicateRequestException extends RuntimeException {
+    public DuplicateRequestException() {
+        super("멱등성 체크 위반. 중복 요청입니다.");
+    }
+
+    public DuplicateRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/noljo/nolzo/global/error/exception/SeatException.java
+++ b/src/main/java/com/noljo/nolzo/global/error/exception/SeatException.java
@@ -1,0 +1,15 @@
+package com.noljo.nolzo.global.error.exception;
+
+public class SeatException extends RuntimeException {
+    public SeatException(Long id) {
+        super("Seat with id " + id + " is already reserved.");
+    }
+
+    public SeatException(String message) {
+        super(message);
+    }
+
+    public SeatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/noljo/nolzo/global/error/handler/GlobalErrorCode.java
+++ b/src/main/java/com/noljo/nolzo/global/error/handler/GlobalErrorCode.java
@@ -14,7 +14,8 @@ public enum GlobalErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     MISSING_HEADER(HttpStatus.BAD_REQUEST, "요청에 필요한 헤더가 존재하지 않습니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다."),
+    DUPLICATE_REQUEST(HttpStatus.BAD_REQUEST,"멱등성 체크 위반. 중복 요청입니다.");
 
     public static final String PREFIX = "[GLOBAL ERROR] ";
 

--- a/src/main/java/com/noljo/nolzo/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/noljo/nolzo/global/error/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.global.error.handler;
 import com.noljo.nolzo.global.error.core.BaseException;
 import com.noljo.nolzo.global.error.core.ErrorCode;
 import com.noljo.nolzo.global.error.core.ErrorResponse;
+import com.noljo.nolzo.global.error.exception.DuplicateRequestException;
 import com.noljo.nolzo.global.utils.GlobalLogger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,6 +24,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return getErrorResponse(e,GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(DuplicateRequestException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateRequestException(DuplicateRequestException e) {
+        return getErrorResponse(e, GlobalErrorCode.DUPLICATE_REQUEST);
     }
 
     private static ResponseEntity<ErrorResponse> getErrorResponse(Exception e, GlobalErrorCode errorCode) {

--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -24,10 +24,13 @@ public class ReservationController {
     private final ReservationService reservationService;
     private final SeatService seatService;
 
-    @PostMapping
-    public ResponseEntity<ReservationResponse> create(@AuthenticationPrincipal CustomUserDetails user,
-                                                      @RequestBody ReservationRequest request) {
-        return ResponseEntity.ok(reservationService.create(user.getMemberId(), request));
+    @PostMapping("/reservations")
+    public ResponseEntity<ReservationResponse> create(
+            @RequestHeader("Idempotency-Key") String idemKey,
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody ReservationRequest request
+    ) {
+        return ResponseEntity.ok(reservationService.create(user.getMemberId(), request, idemKey));
     }
 
     @PostMapping("/{eventId}")

--- a/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
+++ b/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
@@ -15,6 +15,12 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "reservation",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_reservation_idempotency_key", columnNames = {"idempotency_key"})
+        }
+)
 public class Reservation extends BaseEntity {
 
     @Id
@@ -29,6 +35,9 @@ public class Reservation extends BaseEntity {
 
     private String reservationNumber;
 
+    @Column(name = "idempotency_key", updatable = false, length = 64)
+    private String idempotencyKey;
+
     @OneToMany(mappedBy = "reservation", cascade = CascadeType.REMOVE)
     private List<Ticket> tickets = new ArrayList<>();
 
@@ -37,17 +46,23 @@ public class Reservation extends BaseEntity {
     private Member member;
 
     public Reservation(Long id, ReservationStatus status, int totalPrice, String reservationNumber,
-                       Member member) {
+                       String idempotencyKey, Member member) {
         this.id = id;
         this.status = status;
         this.totalPrice = totalPrice;
         this.reservationNumber = reservationNumber;
+        this.idempotencyKey = idempotencyKey;
         this.member = member;
     }
 
     public Reservation(ReservationStatus status, int totalPrice, String reservationNumber,
+                       Member member, String idempotencyKey) {
+        this(null, status, totalPrice, reservationNumber, idempotencyKey, member);
+    }
+
+    public Reservation(ReservationStatus status, int totalPrice, String reservationNumber,
                        Member member) {
-        this(null, status, totalPrice, reservationNumber, member);
+        this(null, status, totalPrice, reservationNumber, null, member);
     }
 
     public void updateStatus(ReservationStatus reservationStatus) {

--- a/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
@@ -5,6 +5,7 @@ import com.noljo.nolzo.reservation.entity.ReservationStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,58 +21,61 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     }
 
     @Query("""
-    SELECT DISTINCT r FROM Reservation r
-    JOIN FETCH r.tickets t
-    JOIN FETCH t.seat s
-    JOIN FETCH s.schedule sch
-    JOIN FETCH sch.event e
-    WHERE r.member.id = :memberId
-""")
+                SELECT DISTINCT r FROM Reservation r
+                JOIN FETCH r.tickets t
+                JOIN FETCH t.seat s
+                JOIN FETCH s.schedule sch
+                JOIN FETCH sch.event e
+                WHERE r.member.id = :memberId
+            """)
     List<Reservation> findReservationsByMemberId(@Param("memberId") Long memberId);
 
 
     @Query("""
-    SELECT DISTINCT r FROM Reservation r
-    JOIN FETCH r.tickets t
-    JOIN FETCH t.seat s
-    JOIN FETCH s.schedule sch
-    JOIN FETCH sch.event e
-    WHERE r.member.id = :memberId
-    AND r.status = 'CONFIRMED'
-""")
+                SELECT DISTINCT r FROM Reservation r
+                JOIN FETCH r.tickets t
+                JOIN FETCH t.seat s
+                JOIN FETCH s.schedule sch
+                JOIN FETCH sch.event e
+                WHERE r.member.id = :memberId
+                AND r.status = 'CONFIRMED'
+            """)
     List<Reservation> findReservationsStatusConfirmedByMemberId(@Param("memberId") Long memberId);
 
     @Query("""
-    SELECT DISTINCT r FROM Reservation r
-    JOIN FETCH r.tickets t
-    JOIN FETCH t.seat s
-    JOIN FETCH s.schedule sch
-    JOIN FETCH sch.event e
-    WHERE r.member.id = :memberId
-    AND t.status = 'USED'
-""")
+                SELECT DISTINCT r FROM Reservation r
+                JOIN FETCH r.tickets t
+                JOIN FETCH t.seat s
+                JOIN FETCH s.schedule sch
+                JOIN FETCH sch.event e
+                WHERE r.member.id = :memberId
+                AND t.status = 'USED'
+            """)
     List<Reservation> findTicketStatusUsedByMemberId(@Param("memberId") Long memberId);
 
     @Query("""
-    SELECT DISTINCT r FROM Reservation r
-    JOIN FETCH r.tickets t
-    JOIN FETCH t.seat s
-    JOIN FETCH s.schedule sch
-    JOIN FETCH sch.event e
-    WHERE r.member.id = :memberId
-      AND (r.status = 'CANCELED' OR t.status = 'CANCELED')
-""")
+                SELECT DISTINCT r FROM Reservation r
+                JOIN FETCH r.tickets t
+                JOIN FETCH t.seat s
+                JOIN FETCH s.schedule sch
+                JOIN FETCH sch.event e
+                WHERE r.member.id = :memberId
+                  AND (r.status = 'CANCELED' OR t.status = 'CANCELED')
+            """)
     List<Reservation> findCanceledReservationsFetchAll(@Param("memberId") Long memberId);
 
     @Query("""
-    SELECT DISTINCT r FROM Reservation r
-    JOIN FETCH r.tickets t
-    JOIN FETCH t.seat s
-    JOIN FETCH s.schedule sch
-    JOIN FETCH sch.event e
-    WHERE r.member.id = :memberId AND r.id = :reservationId
-""")
-    Reservation findReservationDetailsByMemberId(@Param("memberId") Long memberId, @Param("reservationId") Long reservationId);
+                SELECT DISTINCT r FROM Reservation r
+                JOIN FETCH r.tickets t
+                JOIN FETCH t.seat s
+                JOIN FETCH s.schedule sch
+                JOIN FETCH sch.event e
+                WHERE r.member.id = :memberId AND r.id = :reservationId
+            """)
+    Reservation findReservationDetailsByMemberId(@Param("memberId") Long memberId,
+                                                 @Param("reservationId") Long reservationId);
 
     List<Reservation> findByStatusAndCreatedAtBefore(ReservationStatus status, LocalDateTime time);
+
+    Optional<Reservation> findByIdempotencyKey(String idempotencyKey);
 }

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import com.noljo.nolzo.ticket.entity.Ticket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,18 +43,42 @@ public class ReservationService {
     private final PaymentRepository paymentRepository;
     private final TicketService ticketService;
 
+//    @Transactional
+//    @Idempotent(prefix = "reservation:succeed:", key = "#memberId")
+//    public ReservationResponse create(Long memberId, ReservationRequest request) {
+//        Member member = memberRepository.getOrThrow(memberId);
+//        int totalPrice = request.calculateTotalPrice();
+//        Reservation reservation = new Reservation(ReservationStatus.PENDING, totalPrice,
+//                createReservationNumber(), member);
+//
+//        seatService.updateWithReservation(request.seats());
+//        createTicket(request.seats(), reservation);
+//
+//        return ReservationResponse.from(reservationRepository.save(reservation));
+//    }
+
     @Transactional
-    @Idempotent(prefix = "reservation:succeed:", key = "#memberId")
-    public ReservationResponse create(Long memberId, ReservationRequest request) {
+    @Idempotent(prefix = "reservation:", key = "#idemKey")
+    public ReservationResponse create(Long memberId, ReservationRequest request, String idemKey) {
         Member member = memberRepository.getOrThrow(memberId);
         int totalPrice = request.calculateTotalPrice();
-        Reservation reservation = new Reservation(ReservationStatus.PENDING, totalPrice,
-                createReservationNumber(), member);
 
-        seatService.updateWithReservation(request.seats());
-        createTicket(request.seats(), reservation);
+        Reservation reservation = new Reservation(ReservationStatus.PENDING, totalPrice, createReservationNumber(),
+                member, idemKey);
 
-        return ReservationResponse.from(reservationRepository.save(reservation));
+        try {
+            reservationRepository.saveAndFlush(reservation);
+
+            seatService.updateWithReservation(request.seats());
+            createTicket(request.seats(), reservation);
+
+            return ReservationResponse.from(reservation);
+        } catch (DataIntegrityViolationException e) {
+            Reservation existing = reservationRepository.findByIdempotencyKey(idemKey)
+                    .orElseThrow(() -> e);
+
+            return ReservationResponse.from(existing);
+        }
     }
 
     private String createReservationNumber() {

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -42,7 +42,6 @@ public class ReservationService {
     private final PaymentRepository paymentRepository;
     private final TicketService ticketService;
 
-    //todo Permistic lock을 사용해서 구현한 내용 추후 multi-thread or Optimistic Lock or Redis 사용후 비교예정
     @Transactional
     @Idempotent(prefix = "reservation:succeed:", key = "#memberId")
     public ReservationResponse create(Long memberId, ReservationRequest request) {
@@ -56,7 +55,6 @@ public class ReservationService {
 
         return ReservationResponse.from(reservationRepository.save(reservation));
     }
-
 
     private String createReservationNumber() {
         String yearSuffix = String.valueOf(LocalDate.now().getYear()).substring(YEAR_SUFFIX_LENGTH);

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.noljo.nolzo.reservation.service;
 
+import com.noljo.nolzo.global.aop.idempotent.Idempotent;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.repository.EventRepository;
@@ -43,6 +44,7 @@ public class ReservationService {
 
     //todo Permistic lock을 사용해서 구현한 내용 추후 multi-thread or Optimistic Lock or Redis 사용후 비교예정
     @Transactional
+    @Idempotent(prefix = "reservation:succeed:", key = "#memberId")
     public ReservationResponse create(Long memberId, ReservationRequest request) {
         Member member = memberRepository.getOrThrow(memberId);
         int totalPrice = request.calculateTotalPrice();

--- a/src/main/java/com/noljo/nolzo/seat/service/SeatService.java
+++ b/src/main/java/com/noljo/nolzo/seat/service/SeatService.java
@@ -1,6 +1,7 @@
 package com.noljo.nolzo.seat.service;
 
 import com.noljo.nolzo.global.aop.lock.DistributedLock;
+import com.noljo.nolzo.global.error.exception.SeatException;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.schedule.repository.ScheduleRepository;
 import com.noljo.nolzo.seat.dto.SeatResponse;
@@ -13,13 +14,10 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -88,7 +86,7 @@ public class SeatService {
 
     private void validateIsAvailable(Seat seat) {
         if (seat.getStatus() != SeatStatus.AVAILABLE) {
-            throw new IllegalArgumentException("Seat with id " + seat.getId() + " is already reserved.");
+            throw new SeatException(seat.getId());
         }
     }
 

--- a/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
@@ -71,7 +71,7 @@ public class ReservationServiceTest {
 
         Thread thread1 = new Thread(() -> {
             try {
-                reservationService.create(member.getId(), request);
+                reservationService.create(member.getId(), request, "test");
             } catch (Throwable t) {
                 thread1Error.set(t);
             }
@@ -79,7 +79,7 @@ public class ReservationServiceTest {
 
         Thread thread2 = new Thread(() -> {
             try {
-                reservationService.create(anotherMember.getId(), request);
+                reservationService.create(anotherMember.getId(), request, "test2");
             } catch (Throwable t) {
                 thread2Error.set(t);
             }
@@ -105,8 +105,8 @@ public class ReservationServiceTest {
         Schedule schedule = scheduleRepository.save(ScheduleFixture.공연_스케쥴(event));
         event.addSchedule(schedule);
 
-
-        EventDateTimeResponse response = reservationService.readSelectedEventDateTime(event.getId(), schedule.getShowDate(),
+        EventDateTimeResponse response = reservationService.readSelectedEventDateTime(event.getId(),
+                schedule.getShowDate(),
                 schedule.getShowTime());
 
         assertNotNull(response);
@@ -154,10 +154,10 @@ public class ReservationServiceTest {
         Reservation cancelledReservation = reservationRepository.findById(reservation.getId())
                 .orElseThrow(() -> new AssertionError("취소된 예약을 찾을 수 없습니다."));
 
-        assertEquals(ReservationStatus.CANCELLED,cancelledReservation.getStatus());
+        assertEquals(ReservationStatus.CANCELLED, cancelledReservation.getStatus());
         reservation.getTickets().forEach(ticket ->
                 assertEquals(TicketStatus.CANCELLED, ticket.getStatus()));
         reservation2.getTickets().forEach(ticket ->
                 assertEquals(TicketStatus.NOT_USED, ticket.getStatus()));
-        }
+    }
 }

--- a/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
@@ -1,11 +1,13 @@
 package com.noljo.nolzo.domain.reservation.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.global.error.exception.SeatException;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.repository.MemberRepository;
 import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
@@ -24,6 +26,9 @@ import com.noljo.nolzo.support.fixture.*;
 import com.noljo.nolzo.ticket.entity.TicketStatus;
 import com.noljo.nolzo.ticket.repository.TicketRepository;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -61,18 +66,37 @@ public class ReservationServiceTest {
         List<Seat> seats = List.of(seat1);
         ReservationRequest request = new ReservationRequest(event.getId(), seats);
 
-        Thread thread1 = new Thread(() -> reservationService.create(member.getId(), request));
-        Thread thread2 = new Thread(() -> reservationService.create(anotherMember.getId(), request));
+        AtomicReference<Throwable> thread1Error = new AtomicReference<>();
+        AtomicReference<Throwable> thread2Error = new AtomicReference<>();
+
+        Thread thread1 = new Thread(() -> {
+            try {
+                reservationService.create(member.getId(), request);
+            } catch (Throwable t) {
+                thread1Error.set(t);
+            }
+        });
+
+        Thread thread2 = new Thread(() -> {
+            try {
+                reservationService.create(anotherMember.getId(), request);
+            } catch (Throwable t) {
+                thread2Error.set(t);
+            }
+        });
 
         thread1.start();
         thread2.start();
-
         thread1.join();
         thread2.join();
 
-        assertThatThrownBy(() -> reservationService.create(anotherMember.getId(),
-                new ReservationRequest(event.getId(), seats)))
-                .isInstanceOf(IllegalArgumentException.class);
+        Throwable e1 = thread1Error.get();
+        Throwable e2 = thread2Error.get();
+
+        List<Throwable> errors = Arrays.asList(e1, e2);
+
+        assertThat(errors).anyMatch(Objects::isNull);
+        assertThat(errors).anyMatch(e -> e instanceof SeatException);
     }
 
     @Test

--- a/src/test/java/com/noljo/nolzo/support/RedisCleanerExtension.java
+++ b/src/test/java/com/noljo/nolzo/support/RedisCleanerExtension.java
@@ -1,0 +1,23 @@
+package com.noljo.nolzo.support;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class RedisCleanerExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        ApplicationContext applicationContext =
+                SpringExtension.getApplicationContext(context);
+
+        StringRedisTemplate redisTemplate =
+                applicationContext.getBean(StringRedisTemplate.class);
+
+        redisTemplate.getConnectionFactory()
+                .getConnection()
+                .flushDb();
+    }
+}

--- a/src/test/java/com/noljo/nolzo/support/annotation/ServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/support/annotation/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.noljo.nolzo.support.annotation;
 
 import com.noljo.nolzo.support.DatabaseCleanerExtension;
+import com.noljo.nolzo.support.RedisCleanerExtension;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -14,6 +15,9 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Retention(RetentionPolicy.RUNTIME)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@ExtendWith(DatabaseCleanerExtension.class)
+@ExtendWith({
+        DatabaseCleanerExtension.class,
+        RedisCleanerExtension.class
+})
 public @interface ServiceTest {
 }

--- a/src/test/java/com/noljo/nolzo/support/fixture/ReservationFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/ReservationFixture.java
@@ -26,6 +26,6 @@ public enum ReservationFixture {
     }
 
     public static Reservation 예약2(Member member) {
-        return new Reservation(null, 예약2.reservationStatus, 예약2.totalPrice, 예약2.reservationNumber, member);
+        return new Reservation(null, 예약2.reservationStatus, 예약2.totalPrice, 예약2.reservationNumber, null, member);
     }
 }


### PR DESCRIPTION
## 📌 개요

- 예약 화면에서 새로고침 또는 혹시 모를 이슈로 인한 재 예약로직을 막아야한다는 생각을 하게 되었습니다.

* (작업한 코드에 대한 간략한 설명해주세요)
- 멱등성 검사를 위한 Idempotent 어노테이션 개발
- Redis를 사용한 멱등성 검사 구현
- Redis에 문제가 생겼을 경우 검사가 안될 떄를 대비해 UNIQUE KEY 제약 조건을 통한 최종적인 멱등성 보장을 위한 컬럼 추가

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#9`)
### (Idempotency Key를 Redis에 캐싱하여 중복 처리 방지)

- @Idempotent가 적용된 메서드 호출을 가로채고, 멱등성 로직을 수행 -> checkAndSet(): Redis의 setIfAbsent()을 이용하여 키 조회 및 저장을 원자적으로 수행한 후 대상 메서드 실행

### 기술 선택 이유
- 선제적 중복 처리 방지
  - 요청 처리의 가장 초기 단계(AOP 인터셉트)에서 중복 요청을 필터링
  - 불필요한 리소스 낭비(DB 접근, 다른 서비스 호출 등)를 방지하고 핵심 비즈니스 로직의 중복 실행을 원천적으로 차단


### (UNIQUE KEY 제약 조건을 통한 최종적인 멱등성 보장)

- Redis 서버 장애 발생 시 Idempotency Key 조회 및 저장이 불가능한 경우를 대비해서 최종적인 멱득성을 보장하고자 함
- UNIQUE KEY 조건을 건 멱등키를 따로 Reservation 엔티티에 저장하여 관리


## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

close: #9 