### PR TITLE
스케줄러 중복 실행 방지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
 
 	//kafka
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	// ShedLock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0'
 }
 
 tasks.named('test') {

--- a/docs/posts/멀티 인스턴스 환경에서 스케줄러 중복 실행 방지.md
+++ b/docs/posts/멀티 인스턴스 환경에서 스케줄러 중복 실행 방지.md
@@ -1,0 +1,159 @@
+# ⚠️ 문제: 멀티 인스턴스 환경에서 스케줄러가 중복 실행될 수 있다.
+
+## 1. 단일 인스턴스에서는 문제가 없던 `@Scheduled`가 왜 멀티 인스턴스에서 문제가 될까?
+- Spring의 `@Scheduled`는 각 애플리케이션 인스턴스 내부에서 독립적으로 동작한다.
+- 따라서 서버를 여러 대로 확장하면, 같은 스케줄러 메서드가 인스턴스 수만큼 동시에 실행될 수 있다.
+
+## ❓1.1. 실제로 어떤 문제가 생길 수 있을까?
+- 동일한 배치 작업이 여러 서버에서 동시에 수행되어 중복 처리될 수 있다.
+- 예약 자동 취소 작업이 동시에 실행되면 동일 예약을 여러 번 취소하려 시도할 수 있다.
+- 대기열 처리 작업이 동시에 실행되면 같은 이벤트에 대해 활성 인원 계산과 승급 로직이 겹칠 수 있다.
+- 결과적으로 불필요한 DB 조회 및 갱신이 반복되고, 로그가 중복되며 상태 정합성 관리가 어려워질 수 있다.
+
+```java
+@Scheduled(fixedRate = 60000)
+@Transactional
+public void cancelUnpaidReservations() {...}
+
+@Scheduled(fixedDelay = 1000)
+public void processReservationQueues() {...}
+```
+
+- 위 로직들은 단일 인스턴스에서는 자연스럽게 동작하지만, 서버가 여러 대가 되면 모든 인스턴스가 같은 시점에 메서드를 실행하려고 시도한다.
+
+---
+
+# 💡해결 방법
+
+## 해결: `ShedLock`과 MySQL 기반 JDBC Provider를 사용하여 하나의 인스턴스만 스케줄러 실행
+- 스케줄러 실행 전 공용 저장소에 락을 기록하고, 락을 획득한 인스턴스만 작업을 수행하도록 한다.
+- 이번 프로젝트는 이미 MySQL을 사용하고 있으므로 별도 Redis 락 저장소를 추가하지 않고 DB를 락 저장소로 사용했다.
+  - Redis 장애 시 복구 프로세스를 이미 별도로 구현해두었기 때문에, 스케줄러 락까지 Redis에 의존시키기보다 역할을 분리해 MySQL을 사용하는 편이 더 적절하다고 판단했다.
+
+## 1. 구현 상세
+
+### 1.1. SchedulerConfig에 LockProvider 등록
+- `@EnableSchedulerLock`으로 스케줄러 락 기능을 활성화
+- `JdbcTemplateLockProvider`를 사용해 락 정보를 MySQL 테이블에 저장
+- `usingDbTime()`으로 애플리케이션 서버 시간이 아닌 DB 시간을 기준으로 락 시간을 계산해 인스턴스 간 시간 차이를 줄임
+
+```java
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
+public class SchedulerConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
+}
+```
+
+### 1.2. 락 테이블 생성
+- ShedLock은 락 상태를 저장할 테이블이 필요하다.
+- MySQL에 아래 테이블을 두고, 각 스케줄러의 락 이름과 만료 시각을 기록한다.
+
+```sql
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL,
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);
+```
+
+### 1.3. 스케줄러 메서드에 `@SchedulerLock` 적용
+
+```java
+@Scheduled(fixedRate = 60000)
+@SchedulerLock(
+        name = "reservationScheduler.cancelUnpaidReservations",
+        lockAtMostFor = "PT50S",
+        lockAtLeastFor = "PT5S"
+)
+@Transactional
+public void cancelUnpaidReservations() {...}
+
+@Scheduled(fixedDelay = 1000)
+@SchedulerLock(
+        name = "reservationScheduler.processReservationQueues",
+        lockAtMostFor = "PT10S",
+        lockAtLeastFor = "PT1S"
+)
+public void processReservationQueues() {...}
+```
+
+<br>
+
+## 2. 기술 선택 이유
+
+### 2-1. 멀티 인스턴스 환경에서 단일 실행 보장
+- 서버가 여러 대여도 동일한 스케줄러는 하나의 인스턴스에서만 실행한다.
+- 이를 통해 배치의 중복 실행을 줄일 수 있다.
+
+### 2-2. 기존 MySQL 인프라 재사용
+- 이미 MySQL을 사용하고 있기 때문에 별도의 락 저장소를 추가할 필요가 없다.
+- 운영 중인 DB를 그대로 활용하므로 인프라 복잡도가 낮다.
+
+### 2-3. 선언적 방식으로 간단한 적용
+- 스케줄러 메서드에 `@SchedulerLock`만 추가하면 적용할 수 있다.
+- 분산 락 로직을 직접 구현하는 것보다 코드가 단순하고 유지보수가 쉽다.
+
+### 2-4. DB 시간 기준 사용으로 시간 오차 완화
+- 여러 애플리케이션 서버의 시스템 시간이 조금씩 다를 수 있다.
+- `usingDbTime()`을 사용하면 DB 시간을 기준으로 락을 계산하므로 인스턴스 간 시간 차이로 인한 오작동 가능성을 낮출 수 있다.
+
+<br>
+
+## 3. 단점 및 트레이드 오프
+
+### 3-1. DB 의존성 증가
+- 스케줄러 락 관리가 MySQL에 의존하게 된다.
+- DB 장애가 발생하면 락 획득 자체가 어려워져 스케줄러 실행에 영향을 줄 수 있다.
+
+### 3-2. 완전한 정합성 보장을 위한 내부 로직 보완 필요
+- ShedLock은 스케줄러 중복 실행을 줄여주지만, 작업 내부 로직을 완전히 원자적으로 만들어주지는 않는다.
+- 예를 들어 대기열 처리처럼 상태 변화가 많은 작업은 여전히 서비스 내부에서 멱등성 확보 처리와 상태 전이 검증이 필요하다.
+
+### 3-3. 락 시간 설정이 부적절하면 문제 발생 가능
+- 락의 최대 유지 시간이 너무 짧으면 작업이 끝나기 전에 락이 먼저 만료되어 다른 인스턴스가 다시 락을 획득할 수 있다.
+  - 반대로 너무 길면 장애 복구가 늦어져 다음 실행이 불필요하게 지연될 수 있다.
+
+<br>
+
+## 4. 다른 방법 및 비교
+### 4.1. Redis 기반 분산 락
+#### 4.1.1. 장점
+- 스케줄러 외에도 다양한 서비스 로직에 재사용할 수 있다.
+
+#### 4.1.2. 단점 및 적합성
+- 락 획득, 해제, 예외 상황 대응을 직접 설계해야 해 구현 복잡도가 높다.
+- 이번 문제는 스케줄러 실행 제어가 핵심인데, 이 경우 ShedLock이 더 선언적이고 단순하다.
+
+- **결론**: 범용 분산 락이 필요할 때는 좋은 선택이지만, 스케줄러 중복 실행 방지라는 목적에는 ShedLock이 더 적합하다고 판단하였다.
+
+<br>
+
+### 4.2. Quartz와 같은 별도 스케줄러 프레임워크
+#### 4.2.1. 장점
+- 복잡한 잡 스케줄링, 상태 관리, 실패 재시도 등 풍부한 기능을 제공한다.
+
+#### 4.2.2. 단점 및 적합성
+- 단순 주기성 작업에 비해 설정과 운영 복잡도가 높다.
+
+- **결론**: 향후 배치 요구사항이 더 복잡해지면 고려할 수 있지만, 현재 단계에서는 ShedLock이 더 가볍고 적절하다.
+
+<br>
+
+## 5. 정리
+- `@Scheduled`는 멀티 인스턴스 환경에서 각 인스턴스마다 독립적으로 실행되므로, 그대로 두면 예약 취소와 대기열 처리 작업이 중복 실행될 수 있다.
+- 이를 해결하기 위해 ShedLock과 MySQL JDBC Provider를 적용하여, 동일한 스케줄러를 한 번에 하나의 인스턴스만 실행하도록 구성했다.
+- 또한 DB 시간을 기준으로 락을 계산하여 인스턴스 간 시간 차이 문제를 줄였고, 기존 MySQL 인프라를 그대로 재사용해 운영 복잡도를 낮췄다.
+- 이를 통해 분산 환경에서도 스케줄러 중복 실행 위험을 줄이고, 예약 및 대기열 처리의 안정성을 높일 수 있었다.

--- a/src/main/java/com/noljo/nolzo/global/config/SchedulerConfig.java
+++ b/src/main/java/com/noljo/nolzo/global/config/SchedulerConfig.java
@@ -1,9 +1,26 @@
 package com.noljo.nolzo.global.config;
 
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @Configuration
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
 public class SchedulerConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
 }

--- a/src/main/java/com/noljo/nolzo/reservation/scheduler/ReservationScheduler.java
+++ b/src/main/java/com/noljo/nolzo/reservation/scheduler/ReservationScheduler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,11 @@ public class ReservationScheduler {
      * 매 1분마다 실행 → 5분이 지난 PENDING 예약은 자동 취소
      */
     @Scheduled(fixedRate = 60000)
+    @SchedulerLock(
+            name = "reservationScheduler.cancelUnpaidReservations",
+            lockAtMostFor = "PT50S",
+            lockAtLeastFor = "PT5S"
+    )
     @Transactional
     public void cancelUnpaidReservations() {
         LocalDateTime deadline = LocalDateTime.now().minusMinutes(1);
@@ -45,6 +51,11 @@ public class ReservationScheduler {
      * 매 1초마다 실행 → 예매 대기열 처리
      */
     @Scheduled(fixedDelay = 1000)
+    @SchedulerLock(
+            name = "reservationScheduler.processReservationQueues",
+            lockAtMostFor = "PT10S",
+            lockAtLeastFor = "PT1S"
+    )
     public void processReservationQueues() {
         Set<Object> managedEventIds = queueService.getManagedEventIds();
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL,
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/src/test/java/com/noljo/nolzo/support/DatabaseCleaner.java
+++ b/src/test/java/com/noljo/nolzo/support/DatabaseCleaner.java
@@ -18,6 +18,7 @@ public class DatabaseCleaner {
     private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
     private static final String ID_RESET_FORMAT = "ALTER TABLE %s AUTO_INCREMENT = 1"; // MySQL의 ID 리셋 형식
     private static final String REFERENTIAL_FORMAT = "SET FOREIGN_KEY_CHECKS = %s"; // MySQL에서는 외래 키 체크 비활성화
+    private static final String SHEDLOCK_TABLE = "SHEDLOCK";
 
     private final EntityManager entityManager;
     private final DataSource dataSource;
@@ -34,7 +35,9 @@ public class DatabaseCleaner {
         entityManager.createNativeQuery(String.format(REFERENTIAL_FORMAT, "0")).executeUpdate(); // FOREIGN_KEY_CHECKS = 0
         tableNames.forEach(tableName -> {
             entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
-            entityManager.createNativeQuery(String.format(ID_RESET_FORMAT, tableName)).executeUpdate(); // AUTO_INCREMENT 리셋
+            if (!SHEDLOCK_TABLE.equalsIgnoreCase(tableName)) {
+                entityManager.createNativeQuery(String.format(ID_RESET_FORMAT, tableName)).executeUpdate(); // AUTO_INCREMENT 리셋
+            }
         });
         entityManager.createNativeQuery(String.format(REFERENTIAL_FORMAT, "1")).executeUpdate(); // FOREIGN_KEY_CHECKS = 1
     }


### PR DESCRIPTION
## 📌 개요

* 멀티 인스턴스 환경에서 스케줄러가 각 서버 인스턴스마다 중복 실행되는 문제를 방지하기 위해 분산 락 기반의 스케줄러 실행 제어를 적용했습니다.
* 기존에는 애플리케이션 인스턴스가 여러 개 실행될 경우, 동일한 `@Scheduled` 작업이 각 인스턴스에서 동시에 실행될 수 있었습니다.
* 이를 해결하기 위해 `ShedLock`을 적용하여 특정 스케줄러 작업은 하나의 인스턴스에서만 실행되도록 개선했습니다.

## 🛠️ 작업 내용

- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#15`)

### 멀티 인스턴스 환경에서의 스케줄러 중복 실행 문제 해결

* 기존 스케줄러는 `@Scheduled`만 사용하고 있었기 때문에, 서버가 여러 대 실행되는 환경에서는 동일한 작업이 인스턴스 수만큼 중복 실행될 수 있었습니다.
* 예를 들어 예약 만료 처리, 대기열 처리 같은 작업이 여러 인스턴스에서 동시에 실행되면 동일 데이터를 중복 처리하거나, 불필요한 DB/Redis 부하가 발생할 수 있습니다.
* 이를 방지하기 위해 스케줄러 실행 시 분산 락을 획득한 인스턴스만 작업을 수행하도록 `ShedLock`을 적용했습니다.

| 이미지① |
| :----: |
| |

### ShedLock 기반 분산 락 적용

* 스케줄러 메서드에 `@SchedulerLock`을 적용하여 동일한 작업 이름에 대해 하나의 인스턴스만 락을 획득하고 실행할 수 있도록 변경했습니다.
* `lockAtMostFor`를 설정하여 스케줄러 실행 중 인스턴스가 비정상 종료되더라도 락이 영구적으로 유지되지 않도록 했습니다.
* `lockAtLeastFor`를 설정하여 너무 짧은 시간 안에 동일 작업이 반복 실행되는 것을 방지했습니다.


## 📌 차후 계획 (Optional)

* (작업한 코드가 추후 우리 프로젝트에 어떤 영향을 끼칠지, 앞으로 PR계획을 설명해주세요)
- 현재는 주요 예약/대기열 스케줄러에 대해 분산 락을 적용했으며, 추후 새로운 스케줄러가 추가될 경우 동일하게 @SchedulerLock 적용 여부를 검토할 예정입니다.
- 스케줄러 작업 시간이 길어질 가능성이 있는 경우 lockAtMostFor, lockAtLeastFor 값을 실제 운영 환경 기준으로 조정할 필요가 있습니다.
- 추후 모니터링을 통해 락 획득 실패, 스케줄러 실행 시간, 중복 실행 방지 여부를 확인할 수 있도록 로그 또는 메트릭을 보강할 수 있습니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close : #15 