### PR TITLE
[Feature] 빈자리 알림을 위한 구독기능 구현

### DIFF
--- a/nolzo-api/src/main/java/com/noljo/nolzo/notification/controller/NotificationSubscriptionController.java
+++ b/nolzo-api/src/main/java/com/noljo/nolzo/notification/controller/NotificationSubscriptionController.java
@@ -1,0 +1,56 @@
+package com.noljo.nolzo.notification.controller;
+
+import com.noljo.nolzo.notification.application.port.in.CancelSeatAvailabilitySubscriptionUseCase;
+import com.noljo.nolzo.notification.application.port.in.CreateSeatAvailabilitySubscriptionUseCase;
+import com.noljo.nolzo.notification.application.port.in.GetSeatAvailabilitySubscriptionUseCase;
+import com.noljo.nolzo.notification.dto.CreateSeatAvailabilitySubscriptionRequest;
+import com.noljo.nolzo.notification.dto.SeatAvailabilitySubscriptionResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications/subscriptions")
+public class NotificationSubscriptionController {
+
+    private final CreateSeatAvailabilitySubscriptionUseCase createSeatAvailabilitySubscriptionUseCase;
+    private final CancelSeatAvailabilitySubscriptionUseCase cancelSeatAvailabilitySubscriptionUseCase;
+    private final GetSeatAvailabilitySubscriptionUseCase getSeatAvailabilitySubscriptionUseCase;
+
+    @PostMapping
+    public ResponseEntity<SeatAvailabilitySubscriptionResponse> create(
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
+            @RequestBody CreateSeatAvailabilitySubscriptionRequest request
+    ) {
+        return ResponseEntity.ok(
+                createSeatAvailabilitySubscriptionUseCase.create(memberId, request)
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SeatAvailabilitySubscriptionResponse>> readAll(
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
+    ) {
+        return ResponseEntity.ok(
+                getSeatAvailabilitySubscriptionUseCase.readAllByMemberId(memberId)
+        );
+    }
+
+    @DeleteMapping("/{subscriptionId}")
+    public ResponseEntity<Void> cancel(
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
+            @PathVariable Long subscriptionId
+    ) {
+        cancelSeatAvailabilitySubscriptionUseCase.cancel(memberId, subscriptionId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailabilitySubscriptionServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailabilitySubscriptionServiceTest.java
@@ -53,7 +53,7 @@ class SeatAvailabilitySubscriptionServiceTest {
                 member.getId(),
                 request(event.getId(), schedule.getId(), SectionPrice.SECTION_1)
         );
-        
+
         assertThat(response.getMemberId()).isEqualTo(member.getId());
         assertThat(response.getEventId()).isEqualTo(event.getId());
         assertThat(response.getEventScheduleId()).isEqualTo(schedule.getId());

--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailabilitySubscriptionServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailabilitySubscriptionServiceTest.java
@@ -1,0 +1,129 @@
+package com.noljo.nolzo.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.noljo.nolzo.event.application.port.out.EventPersistencePort;
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.member.application.port.out.MemberPersistencePort;
+import com.noljo.nolzo.member.entity.Member;
+import com.noljo.nolzo.notification.domain.NotificationChannel;
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+import com.noljo.nolzo.notification.domain.SubscriptionStatus;
+import com.noljo.nolzo.notification.dto.CreateSeatAvailabilitySubscriptionRequest;
+import com.noljo.nolzo.notification.dto.SeatAvailabilitySubscriptionResponse;
+import com.noljo.nolzo.notification.repository.SeatAvailabilitySubscriptionRepository;
+import com.noljo.nolzo.notification.service.SeatAvailabilitySubscriptionService;
+import com.noljo.nolzo.schedule.application.port.out.SchedulePersistencePort;
+import com.noljo.nolzo.schedule.entity.Schedule;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import com.noljo.nolzo.support.annotation.ServiceTest;
+import com.noljo.nolzo.support.fixture.EventFixture;
+import com.noljo.nolzo.support.fixture.MemberFixture;
+import com.noljo.nolzo.support.fixture.ScheduleFixture;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ServiceTest
+class SeatAvailabilitySubscriptionServiceTest {
+
+    @Autowired
+    private SeatAvailabilitySubscriptionService seatAvailabilitySubscriptionService;
+
+    @Autowired
+    private SeatAvailabilitySubscriptionRepository seatAvailabilitySubscriptionRepository;
+
+    @Autowired
+    private MemberPersistencePort memberPersistencePort;
+
+    @Autowired
+    private EventPersistencePort eventPersistencePort;
+
+    @Autowired
+    private SchedulePersistencePort schedulePersistencePort;
+
+    @Test
+    void 빈자리_알림_구독을_생성할_수_있다() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+
+        SeatAvailabilitySubscriptionResponse response = seatAvailabilitySubscriptionService.create(
+                member.getId(),
+                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1)
+        );
+        
+        assertThat(response.getMemberId()).isEqualTo(member.getId());
+        assertThat(response.getEventId()).isEqualTo(event.getId());
+        assertThat(response.getEventScheduleId()).isEqualTo(schedule.getId());
+        assertThat(response.getSeatGrade()).isEqualTo(SectionPrice.SECTION_1);
+        assertThat(response.getChannel()).isEqualTo(NotificationChannel.EMAIL);
+        assertThat(response.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    }
+
+    @Test
+    void 동일한_빈자리_알림을_이미_구독중이면_예외가_발생한다() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+        CreateSeatAvailabilitySubscriptionRequest request =
+                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1);
+
+        seatAvailabilitySubscriptionService.create(member.getId(), request);
+
+        assertThatThrownBy(() -> seatAvailabilitySubscriptionService.create(member.getId(), request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 동일한 빈자리 알림을 구독 중입니다.");
+    }
+
+    @Test
+    void 구독을_해지할_수_있다() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+
+        SeatAvailabilitySubscriptionResponse response = seatAvailabilitySubscriptionService.create(
+                member.getId(),
+                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1)
+        );
+
+        seatAvailabilitySubscriptionService.cancel(member.getId(), response.getId());
+
+        SeatAvailabilitySubscription subscription = seatAvailabilitySubscriptionRepository.findById(response.getId())
+                .orElseThrow();
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.UNSUBSCRIBED);
+    }
+
+    @Test
+    void 해지된_구독은_같은_조건으로_다시_구독하면_재활성화된다() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+        CreateSeatAvailabilitySubscriptionRequest request =
+                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1);
+
+        SeatAvailabilitySubscriptionResponse created = seatAvailabilitySubscriptionService.create(member.getId(), request);
+        seatAvailabilitySubscriptionService.cancel(member.getId(), created.getId());
+
+        SeatAvailabilitySubscriptionResponse recreated = seatAvailabilitySubscriptionService.create(member.getId(), request);
+
+        List<SeatAvailabilitySubscription> subscriptions = seatAvailabilitySubscriptionRepository.findAll();
+        assertThat(subscriptions).hasSize(1);
+        assertThat(recreated.getId()).isEqualTo(created.getId());
+        assertThat(subscriptions.get(0).getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    }
+
+    private CreateSeatAvailabilitySubscriptionRequest request(
+            Long eventId,
+            Long scheduleId,
+            SectionPrice seatGrade
+    ) {
+        return new CreateSeatAvailabilitySubscriptionRequest(
+                eventId,
+                scheduleId,
+                seatGrade,
+                NotificationChannel.EMAIL
+        );
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/in/CancelSeatAvailabilitySubscriptionUseCase.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/in/CancelSeatAvailabilitySubscriptionUseCase.java
@@ -1,0 +1,6 @@
+package com.noljo.nolzo.notification.application.port.in;
+
+public interface CancelSeatAvailabilitySubscriptionUseCase {
+
+    void cancel(Long memberId, Long subscriptionId);
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/in/CreateSeatAvailabilitySubscriptionUseCase.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/in/CreateSeatAvailabilitySubscriptionUseCase.java
@@ -1,0 +1,12 @@
+package com.noljo.nolzo.notification.application.port.in;
+
+import com.noljo.nolzo.notification.dto.CreateSeatAvailabilitySubscriptionRequest;
+import com.noljo.nolzo.notification.dto.SeatAvailabilitySubscriptionResponse;
+
+public interface CreateSeatAvailabilitySubscriptionUseCase {
+
+    SeatAvailabilitySubscriptionResponse create(
+            Long memberId,
+            CreateSeatAvailabilitySubscriptionRequest request
+    );
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/in/GetSeatAvailabilitySubscriptionUseCase.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/in/GetSeatAvailabilitySubscriptionUseCase.java
@@ -1,0 +1,9 @@
+package com.noljo.nolzo.notification.application.port.in;
+
+import com.noljo.nolzo.notification.dto.SeatAvailabilitySubscriptionResponse;
+import java.util.List;
+
+public interface GetSeatAvailabilitySubscriptionUseCase {
+
+    List<SeatAvailabilitySubscriptionResponse> readAllByMemberId(Long memberId);
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadSeatAvailabilitySubscriptionPort.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadSeatAvailabilitySubscriptionPort.java
@@ -1,0 +1,26 @@
+package com.noljo.nolzo.notification.application.port.out;
+
+import com.noljo.nolzo.notification.domain.NotificationChannel;
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+import com.noljo.nolzo.notification.domain.SubscriptionStatus;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import java.util.List;
+import java.util.Optional;
+
+public interface LoadSeatAvailabilitySubscriptionPort {
+
+    Optional<SeatAvailabilitySubscription> findExistingSubscription(
+            Long memberId,
+            Long eventId,
+            Long eventScheduleId,
+            SectionPrice seatGrade,
+            NotificationChannel channel
+    );
+
+    List<SeatAvailabilitySubscription> findAllByMemberIdAndStatus(
+            Long memberId,
+            SubscriptionStatus status
+    );
+
+    Optional<SeatAvailabilitySubscription> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/SaveSeatAvailabilitySubscriptionPort.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/SaveSeatAvailabilitySubscriptionPort.java
@@ -1,0 +1,8 @@
+package com.noljo.nolzo.notification.application.port.out;
+
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+
+public interface SaveSeatAvailabilitySubscriptionPort {
+
+    SeatAvailabilitySubscription save(SeatAvailabilitySubscription subscription);
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/NotificationChannel.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/NotificationChannel.java
@@ -1,0 +1,5 @@
+package com.noljo.nolzo.notification.domain;
+
+public enum NotificationChannel {
+    EMAIL
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/SeatAvailabilitySubscription.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/SeatAvailabilitySubscription.java
@@ -1,0 +1,93 @@
+package com.noljo.nolzo.notification.domain;
+
+import com.noljo.nolzo.global.BaseEntity;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "seat_availability_subscription",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_subscription_member_event_schedule_grade_channel",
+                        columnNames = {"member_id", "event_id", "event_schedule_id", "seat_grade", "channel"}
+                )
+        }
+)
+public class SeatAvailabilitySubscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscription_id")
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "event_schedule_id", nullable = false)
+    private Long eventScheduleId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "seat_grade", nullable = false)
+    private SectionPrice seatGrade;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false)
+    private NotificationChannel channel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SubscriptionStatus status;
+
+    @Column(name = "last_notified_at")
+    private LocalDateTime lastNotifiedAt;
+
+    public SeatAvailabilitySubscription(
+            Long memberId,
+            Long eventId,
+            Long eventScheduleId,
+            SectionPrice seatGrade,
+            NotificationChannel channel,
+            SubscriptionStatus status
+    ) {
+        this.memberId = memberId;
+        this.eventId = eventId;
+        this.eventScheduleId = eventScheduleId;
+        this.seatGrade = seatGrade;
+        this.channel = channel;
+        this.status = status;
+    }
+
+    public boolean isActive() {
+        return status == SubscriptionStatus.ACTIVE;
+    }
+
+    public void activate() {
+        this.status = SubscriptionStatus.ACTIVE;
+    }
+
+    public void unsubscribe() {
+        this.status = SubscriptionStatus.UNSUBSCRIBED;
+    }
+
+    public void updateLastNotifiedAt(LocalDateTime lastNotifiedAt) {
+        this.lastNotifiedAt = lastNotifiedAt;
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/SubscriptionStatus.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/SubscriptionStatus.java
@@ -1,0 +1,6 @@
+package com.noljo.nolzo.notification.domain;
+
+public enum SubscriptionStatus {
+    ACTIVE,
+    UNSUBSCRIBED
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/CreateSeatAvailabilitySubscriptionRequest.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/CreateSeatAvailabilitySubscriptionRequest.java
@@ -1,0 +1,12 @@
+package com.noljo.nolzo.notification.dto;
+
+import com.noljo.nolzo.notification.domain.NotificationChannel;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+
+public record CreateSeatAvailabilitySubscriptionRequest(
+        Long eventId,
+        Long eventScheduleId,
+        SectionPrice seatGrade,
+        NotificationChannel channel
+) {
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/SeatAvailabilitySubscriptionResponse.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/SeatAvailabilitySubscriptionResponse.java
@@ -1,0 +1,38 @@
+package com.noljo.nolzo.notification.dto;
+
+import com.noljo.nolzo.notification.domain.NotificationChannel;
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+import com.noljo.nolzo.notification.domain.SubscriptionStatus;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SeatAvailabilitySubscriptionResponse {
+
+    private Long id;
+    private Long memberId;
+    private Long eventId;
+    private Long eventScheduleId;
+    private SectionPrice seatGrade;
+    private NotificationChannel channel;
+    private SubscriptionStatus status;
+    private LocalDateTime lastNotifiedAt;
+    private LocalDateTime createdAt;
+
+    public static SeatAvailabilitySubscriptionResponse from(SeatAvailabilitySubscription subscription) {
+        return SeatAvailabilitySubscriptionResponse.builder()
+                .id(subscription.getId())
+                .memberId(subscription.getMemberId())
+                .eventId(subscription.getEventId())
+                .eventScheduleId(subscription.getEventScheduleId())
+                .seatGrade(subscription.getSeatGrade())
+                .channel(subscription.getChannel())
+                .status(subscription.getStatus())
+                .lastNotifiedAt(subscription.getLastNotifiedAt())
+                .createdAt(subscription.getCreatedAt())
+                .build();
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailabilitySubscriptionService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailabilitySubscriptionService.java
@@ -1,0 +1,113 @@
+package com.noljo.nolzo.notification.service;
+
+import com.noljo.nolzo.event.application.port.out.EventPersistencePort;
+import com.noljo.nolzo.member.application.port.out.MemberPersistencePort;
+import com.noljo.nolzo.notification.application.port.in.CancelSeatAvailabilitySubscriptionUseCase;
+import com.noljo.nolzo.notification.application.port.in.CreateSeatAvailabilitySubscriptionUseCase;
+import com.noljo.nolzo.notification.application.port.in.GetSeatAvailabilitySubscriptionUseCase;
+import com.noljo.nolzo.notification.application.port.out.LoadSeatAvailabilitySubscriptionPort;
+import com.noljo.nolzo.notification.application.port.out.SaveSeatAvailabilitySubscriptionPort;
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+import com.noljo.nolzo.notification.domain.SubscriptionStatus;
+import com.noljo.nolzo.notification.dto.CreateSeatAvailabilitySubscriptionRequest;
+import com.noljo.nolzo.notification.dto.SeatAvailabilitySubscriptionResponse;
+import com.noljo.nolzo.schedule.application.port.out.SchedulePersistencePort;
+import com.noljo.nolzo.schedule.entity.Schedule;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SeatAvailabilitySubscriptionService implements
+        CreateSeatAvailabilitySubscriptionUseCase,
+        CancelSeatAvailabilitySubscriptionUseCase,
+        GetSeatAvailabilitySubscriptionUseCase {
+
+    private final SaveSeatAvailabilitySubscriptionPort saveSeatAvailabilitySubscriptionPort;
+    private final LoadSeatAvailabilitySubscriptionPort loadSeatAvailabilitySubscriptionPort;
+    private final MemberPersistencePort memberPersistencePort;
+    private final EventPersistencePort eventPersistencePort;
+    private final SchedulePersistencePort schedulePersistencePort;
+
+    @Override
+    @Transactional
+    public SeatAvailabilitySubscriptionResponse create(
+            Long memberId,
+            CreateSeatAvailabilitySubscriptionRequest request
+    ) {
+        validateCreate(memberId, request);
+
+        SeatAvailabilitySubscription existing = loadSeatAvailabilitySubscriptionPort
+                .findExistingSubscription(
+                        memberId,
+                        request.eventId(),
+                        request.eventScheduleId(),
+                        request.seatGrade(),
+                        request.channel()
+                )
+                .orElse(null);
+
+        if (existing != null) {
+            if (existing.isActive()) {
+                throw new IllegalArgumentException("이미 동일한 빈자리 알림을 구독 중입니다.");
+            }
+
+            existing.activate();
+            return SeatAvailabilitySubscriptionResponse.from(
+                    saveSeatAvailabilitySubscriptionPort.save(existing)
+            );
+        }
+
+        SeatAvailabilitySubscription subscription = new SeatAvailabilitySubscription(
+                memberId,
+                request.eventId(),
+                request.eventScheduleId(),
+                request.seatGrade(),
+                request.channel(),
+                SubscriptionStatus.ACTIVE
+        );
+
+        return SeatAvailabilitySubscriptionResponse.from(
+                saveSeatAvailabilitySubscriptionPort.save(subscription)
+        );
+    }
+
+    @Override
+    @Transactional
+    public void cancel(Long memberId, Long subscriptionId) {
+        SeatAvailabilitySubscription subscription = loadSeatAvailabilitySubscriptionPort.findByIdAndMemberId(
+                subscriptionId,
+                memberId
+        ).orElseThrow(() -> new IllegalArgumentException("해당 구독 정보가 없습니다."));
+
+        if (!subscription.isActive()) {
+            throw new IllegalArgumentException("이미 해지된 구독입니다.");
+        }
+
+        subscription.unsubscribe();
+    }
+
+    @Override
+    public List<SeatAvailabilitySubscriptionResponse> readAllByMemberId(Long memberId) {
+        return loadSeatAvailabilitySubscriptionPort.findAllByMemberIdAndStatus(
+                        memberId,
+                        SubscriptionStatus.ACTIVE
+                ).stream()
+                .map(SeatAvailabilitySubscriptionResponse::from)
+                .toList();
+    }
+
+    private void validateCreate(Long memberId, CreateSeatAvailabilitySubscriptionRequest request) {
+        memberPersistencePort.getOrThrow(memberId);
+        eventPersistencePort.getOrThrow(request.eventId());
+
+        Schedule schedule = schedulePersistencePort.findById(request.eventScheduleId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회차입니다."));
+
+        if (!schedule.getEvent().getId().equals(request.eventId())) {
+            throw new IllegalArgumentException("해당 이벤트에 속하지 않은 회차입니다.");
+        }
+    }
+}

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/SeatAvailabilitySubscriptionPersistenceAdapter.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/SeatAvailabilitySubscriptionPersistenceAdapter.java
@@ -1,0 +1,60 @@
+package com.noljo.nolzo.notification.adapter.out.persistence;
+
+import com.noljo.nolzo.notification.application.port.out.LoadSeatAvailabilitySubscriptionPort;
+import com.noljo.nolzo.notification.application.port.out.SaveSeatAvailabilitySubscriptionPort;
+import com.noljo.nolzo.notification.domain.NotificationChannel;
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+import com.noljo.nolzo.notification.domain.SubscriptionStatus;
+import com.noljo.nolzo.notification.repository.SeatAvailabilitySubscriptionRepository;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SeatAvailabilitySubscriptionPersistenceAdapter implements
+        SaveSeatAvailabilitySubscriptionPort,
+        LoadSeatAvailabilitySubscriptionPort {
+
+    private final SeatAvailabilitySubscriptionRepository seatAvailabilitySubscriptionRepository;
+
+    @Override
+    public SeatAvailabilitySubscription save(SeatAvailabilitySubscription subscription) {
+        return seatAvailabilitySubscriptionRepository.save(subscription);
+    }
+
+    @Override
+    public Optional<SeatAvailabilitySubscription> findExistingSubscription(
+            Long memberId,
+            Long eventId,
+            Long eventScheduleId,
+            SectionPrice seatGrade,
+            NotificationChannel channel
+    ) {
+        return seatAvailabilitySubscriptionRepository.findExistingSubscription(
+                memberId,
+                eventId,
+                eventScheduleId,
+                seatGrade,
+                channel
+        );
+    }
+
+    @Override
+    public List<SeatAvailabilitySubscription> findAllByMemberIdAndStatus(
+            Long memberId,
+            SubscriptionStatus status
+    ) {
+        return seatAvailabilitySubscriptionRepository.findAllByMemberIdAndStatus(
+                memberId,
+                status
+        );
+    }
+
+    @Override
+    public Optional<SeatAvailabilitySubscription> findByIdAndMemberId(Long id, Long memberId) {
+        return seatAvailabilitySubscriptionRepository.findByIdAndMemberId(id, memberId);
+    }
+}

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/SeatAvailabilitySubscriptionRepository.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/SeatAvailabilitySubscriptionRepository.java
@@ -1,0 +1,45 @@
+package com.noljo.nolzo.notification.repository;
+
+import com.noljo.nolzo.notification.domain.NotificationChannel;
+import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
+import com.noljo.nolzo.notification.domain.SubscriptionStatus;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SeatAvailabilitySubscriptionRepository extends JpaRepository<SeatAvailabilitySubscription, Long> {
+
+    @Query("""
+            select s
+            from SeatAvailabilitySubscription s
+            where s.memberId = :memberId
+              and s.eventId = :eventId
+              and s.eventScheduleId = :eventScheduleId
+              and s.seatGrade = :seatGrade
+              and s.channel = :channel
+            """)
+    Optional<SeatAvailabilitySubscription> findExistingSubscription(
+            @Param("memberId") Long memberId,
+            @Param("eventId") Long eventId,
+            @Param("eventScheduleId") Long eventScheduleId,
+            @Param("seatGrade") SectionPrice seatGrade,
+            @Param("channel") NotificationChannel channel
+    );
+
+    @Query("""
+            select s
+            from SeatAvailabilitySubscription s
+            where s.memberId = :memberId
+              and s.status = :status
+            order by s.createdAt desc
+            """)
+    List<SeatAvailabilitySubscription> findAllByMemberIdAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("status") SubscriptionStatus status
+    );
+
+    Optional<SeatAvailabilitySubscription> findByIdAndMemberId(Long id, Long memberId);
+}


### PR DESCRIPTION
## 📌 개요

* 빈자리 알림 기능의 선행 작업으로, 사용자가 특정 공연/회차/좌석 등급에 대해 빈자리 알림을 구독하고 조회하거나 해지할 수 있는 구독 기능을 구현했습니다.
* 알림 발송 로직 자체는 아직 포함하지 않고, 이후 Kafka 기반 빈자리 이벤트 및 알림 발송 기능을 연결할 수 있도록 구독 도메인, 서비스, API, persistence 구조를 먼저 마련했습니다.

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#21`)

* `notification` 도메인을 새로 추가하고 `SeatAvailabilitySubscription`, `NotificationChannel`, `SubscriptionStatus`를 정의했습니다.
* 사용자가 동일한 조건으로 빈자리 알림을 구독할 수 있도록 구독 생성/조회/해지 유스케이스와 서비스 레이어를 구현했습니다.
* 구독 기준은 `eventId + eventScheduleId + seatGrade + channel` 조합으로 설계했습니다.
* 동일한 조건으로 이미 활성 구독이 존재하는 경우 중복 구독이 발생하지 않도록 검증 로직을 추가했습니다.
* 이미 해지된 동일 조건 구독이 있는 경우 새 데이터를 생성하지 않고 기존 구독을 재활성화하도록 처리했습니다.
* `nolzo-infra`에 구독 저장/조회용 repository와 persistence adapter를 추가했습니다.
* `nolzo-api`에 구독 생성, 목록 조회, 해지 API를 추가했습니다.
* 기존 테스트 패턴에 맞춰 `@ServiceTest` 기반의 구독 서비스 테스트를 추가했습니다.

## 📌 차후 계획 (Optional)

* 다음 단계에서는 예약 취소, 결제 만료, 관리자 좌석 해제 등으로 좌석이 다시 `AVAILABLE` 상태가 되는 시점에 `SeatAvailableEvent`를 발행하는 구조를 추가할 예정입니다.
* 이후 Kafka producer/consumer를 연결해 빈자리 이벤트를 비동기로 처리하고, 구독자 대상 알림 발송 로직을 확장할 계획입니다.
* 대량 구독자를 고려해 batch fan-out, 알림 이력 관리, 중복 방지, 재시도 정책을 후속 작업으로 추가할 예정입니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

close: #21 