### PR TITLE
[Feature] 예약 취소 시 빈자리 발행 이벤트 추가

### DIFF
--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationSeatAvailableEventTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationSeatAvailableEventTest.java
@@ -1,0 +1,126 @@
+package com.noljo.nolzo.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import com.noljo.nolzo.event.application.port.out.EventPersistencePort;
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.member.application.port.out.MemberPersistencePort;
+import com.noljo.nolzo.member.entity.Member;
+import com.noljo.nolzo.notification.application.port.out.PublishSeatAvailableEventPort;
+import com.noljo.nolzo.notification.domain.event.SeatAvailableEvent;
+import com.noljo.nolzo.reservation.entity.Reservation;
+import com.noljo.nolzo.reservation.entity.ReservationStatus;
+import com.noljo.nolzo.reservation.service.ReservationService;
+import com.noljo.nolzo.schedule.application.port.out.SchedulePersistencePort;
+import com.noljo.nolzo.schedule.entity.Schedule;
+import com.noljo.nolzo.seat.application.port.out.SeatPersistencePort;
+import com.noljo.nolzo.seat.entity.Seat;
+import com.noljo.nolzo.seat.entity.SeatStatus;
+import com.noljo.nolzo.seat.entity.SectionPrice;
+import com.noljo.nolzo.support.annotation.ServiceTest;
+import com.noljo.nolzo.support.fixture.EventFixture;
+import com.noljo.nolzo.support.fixture.MemberFixture;
+import com.noljo.nolzo.support.fixture.ScheduleFixture;
+import com.noljo.nolzo.ticket.application.port.out.TicketPersistencePort;
+import com.noljo.nolzo.ticket.entity.Ticket;
+import com.noljo.nolzo.ticket.entity.TicketStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@ServiceTest
+class ReservationSeatAvailableEventTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private MemberPersistencePort memberPersistencePort;
+
+    @Autowired
+    private EventPersistencePort eventPersistencePort;
+
+    @Autowired
+    private SchedulePersistencePort schedulePersistencePort;
+
+    @Autowired
+    private SeatPersistencePort seatPersistencePort;
+
+    @Autowired
+    private com.noljo.nolzo.reservation.application.port.out.ReservationPersistencePort reservationPersistencePort;
+
+    @Autowired
+    private TicketPersistencePort ticketPersistencePort;
+
+    @SpyBean
+    private PublishSeatAvailableEventPort publishSeatAvailableEventPort;
+
+    @Test
+    void 예약_취소시_빈자리_이벤트를_발행한다() {
+        ReservationSetup setup = createPendingReservationWithTicket();
+
+        reservationService.cancelReservationById(setup.memberId(), setup.reservationId());
+
+        ArgumentCaptor<SeatAvailableEvent> captor = ArgumentCaptor.forClass(SeatAvailableEvent.class);
+        verify(publishSeatAvailableEventPort, atLeastOnce()).publish(captor.capture());
+
+        SeatAvailableEvent event = captor.getValue();
+        assertThat(event.eventId()).isEqualTo(setup.eventId());
+        assertThat(event.availableAt()).isNotNull();
+    }
+
+    @Test
+    void 미결제_예약_자동취소시_빈자리_이벤트를_발행한다() {
+        createPendingReservationWithTicket();
+
+        reservationService.cancelUnpaidReservations(LocalDateTime.now().plusMinutes(1));
+
+        ArgumentCaptor<SeatAvailableEvent> captor = ArgumentCaptor.forClass(SeatAvailableEvent.class);
+        verify(publishSeatAvailableEventPort, atLeastOnce()).publish(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .extracting(SeatAvailableEvent::seatId)
+                .isNotEmpty();
+    }
+
+    private ReservationSetup createPendingReservationWithTicket() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+        Seat seat = seatPersistencePort.save(new Seat(
+                "A",
+                1,
+                "1구역",
+                "1층",
+                SectionPrice.getPriceBySection(1),
+                SeatStatus.WAITING,
+                schedule
+        ));
+
+        Reservation reservation = reservationPersistencePort.save(
+                new Reservation(ReservationStatus.PENDING, seat.getPrice(), "NOLZO2600001", member)
+        );
+        ticketPersistencePort.save(new Ticket(TicketStatus.NOT_USED, reservation, seat));
+
+        return new ReservationSetup(
+                member.getId(),
+                event.getId(),
+                schedule.getId(),
+                seat.getId(),
+                reservation.getId()
+        );
+    }
+
+    private record ReservationSetup(
+            Long memberId,
+            Long eventId,
+            Long scheduleId,
+            Long seatId,
+            Long reservationId
+    ) {
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/PublishSeatAvailableEventPort.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/PublishSeatAvailableEventPort.java
@@ -1,0 +1,8 @@
+package com.noljo.nolzo.notification.application.port.out;
+
+import com.noljo.nolzo.notification.domain.event.SeatAvailableEvent;
+
+public interface PublishSeatAvailableEventPort {
+
+    void publish(SeatAvailableEvent event);
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/event/SeatAvailableEvent.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/event/SeatAvailableEvent.java
@@ -1,0 +1,12 @@
+package com.noljo.nolzo.notification.domain.event;
+
+import java.time.LocalDateTime;
+
+public record SeatAvailableEvent(
+        Long eventId,
+        Long eventScheduleId,
+        Long seatId,
+        String seatGrade,
+        LocalDateTime availableAt
+) {
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -5,6 +5,8 @@ import com.noljo.nolzo.event.application.port.out.EventPersistencePort;
 import com.noljo.nolzo.global.aop.idempotent.Idempotent;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.application.port.out.MemberPersistencePort;
+import com.noljo.nolzo.notification.application.port.out.PublishSeatAvailableEventPort;
+import com.noljo.nolzo.notification.domain.event.SeatAvailableEvent;
 import com.noljo.nolzo.payment.entity.Payment;
 import com.noljo.nolzo.payment.application.port.out.PaymentPersistencePort;
 import com.noljo.nolzo.reservation.application.port.in.ReservationUseCase;
@@ -26,6 +28,7 @@ import com.noljo.nolzo.ticket.application.port.in.TicketUseCase;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +51,7 @@ public class ReservationService implements ReservationUseCase {
     private final PaymentPersistencePort paymentPersistencePort;
     private final TicketUseCase ticketUseCase;
     private final ReservationQueuePort reservationQueuePort;
+    private final PublishSeatAvailableEventPort publishSeatAvailableEventPort;
 
 //    @Transactional
 //    @Idempotent(prefix = "reservation:succeed:", key = "#memberId")
@@ -191,6 +195,7 @@ public class ReservationService implements ReservationUseCase {
         reservation.softDelete();
         reservation.updateStatus(ReservationStatus.CANCELLED);
         reservation.cancelAllTickets();
+        publishSeatAvailableEvents(reservation.getTickets());
 
         return ReservationCancelResponse.from(reservation);
     }
@@ -203,7 +208,25 @@ public class ReservationService implements ReservationUseCase {
         for (Reservation reservation : overdueReservations) {
             log.info("자동 취소 처리: reservationId = {}", reservation.getId());
             seatUseCase.updateWithPayment(reservation.getTickets(), SeatStatus.AVAILABLE);
+            publishSeatAvailableEvents(reservation.getTickets());
             reservationPersistencePort.delete(reservation);
         }
+    }
+
+    private void publishSeatAvailableEvents(List<Ticket> tickets) {
+        List<SeatAvailableEvent> events = new ArrayList<>();
+
+        for (Ticket ticket : tickets) {
+            Seat seat = ticket.getSeat();
+            events.add(new SeatAvailableEvent(
+                    seat.getSchedule().getEvent().getId(),
+                    seat.getSchedule().getId(),
+                    seat.getId(),
+                    seat.getSeatSection(),
+                    LocalDateTime.now()
+            ));
+        }
+
+        events.forEach(publishSeatAvailableEventPort::publish);
     }
 }

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/event/SeatAvailableEventLoggingAdapter.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/event/SeatAvailableEventLoggingAdapter.java
@@ -1,0 +1,16 @@
+package com.noljo.nolzo.notification.adapter.out.event;
+
+import com.noljo.nolzo.notification.application.port.out.PublishSeatAvailableEventPort;
+import com.noljo.nolzo.notification.domain.event.SeatAvailableEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SeatAvailableEventLoggingAdapter implements PublishSeatAvailableEventPort {
+
+    @Override
+    public void publish(SeatAvailableEvent event) {
+        log.info("SeatAvailableEvent published: {}", event);
+    }
+}


### PR DESCRIPTION
## 📌 개요

* 빈자리 알림 기능의 다음 단계로, 좌석이 다시 예매 가능한 상태가 되는 시점에 `SeatAvailableEvent`를 발행하는 구조를 추가했습니다.
* 이 단계에서는 실제 Kafka 전송이나 알림 발송까지는 포함하지 않고, 예약 취소 및 미결제 예약 자동 취소 흐름에서 빈자리 발생 사실을 공통 이벤트로 분리하는 데 집중했습니다.

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#23`)

* `SeatAvailableEvent` 이벤트 모델을 추가하고, 예약 도메인이 빈자리 발생 사실을 표준화된 형태로 전달할 수 있도록 구성했습니다.
* `PublishSeatAvailableEventPort`를 추가하여 예약 서비스가 이벤트 발행 구현체를 직접 알지 않도록 분리했습니다.
* 현재 단계에서는 Kafka 연동 전이기 때문에, infra에는 이벤트 발행 흐름을 확인할 수 있는 logging adapter를 우선 추가했습니다.
* 예약 취소 시 좌석이 다시 비워지는 흐름에서 `SeatAvailableEvent`가 발행되도록 연결했습니다.
* 미결제 예약 자동 취소 시에도 좌석이 다시 `AVAILABLE` 상태가 되면 `SeatAvailableEvent`가 발행되도록 연결했습니다.
* 이벤트 payload는 우선 `eventId`, `eventScheduleId`, `seatId`, `seatGrade`, `availableAt` 정도의 최소 정보만 담도록 설계했습니다.
* 이벤트 발행 이유(`reason`) 필드는 현재 단계에서는 제외하고, “빈자리가 생겼다”는 사실 자체만 전달하도록 단순화했습니다.

## 📌 차후 계획 (Optional)

* 다음 단계에서는 `PublishSeatAvailableEventPort`의 구현체를 실제 Kafka producer로 교체하여 `seat-available-events` 토픽으로 이벤트를 전송할 예정입니다.
* 이후 Kafka consumer를 통해 이벤트를 수신하고, 빈자리 알림 구독자 조회 및 알림 발송 로직과 연결할 계획입니다.
* 장기적으로는 outbox 패턴, 중복 방지, 재시도, batch fan-out 같은 안정성/대용량 처리 요소를 추가해 실제 운영 가능한 이벤트 전달 구조로 확장할 예정입니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

close: #23 