### PR TITLE
[Feature] 빈자리 알림 구독 조건 수정 및 알림처리 로직 구현

### DIFF
--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailabilitySubscriptionServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailabilitySubscriptionServiceTest.java
@@ -16,7 +16,6 @@ import com.noljo.nolzo.notification.repository.SeatAvailabilitySubscriptionRepos
 import com.noljo.nolzo.notification.service.SeatAvailabilitySubscriptionService;
 import com.noljo.nolzo.schedule.application.port.out.SchedulePersistencePort;
 import com.noljo.nolzo.schedule.entity.Schedule;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import com.noljo.nolzo.support.annotation.ServiceTest;
 import com.noljo.nolzo.support.fixture.EventFixture;
 import com.noljo.nolzo.support.fixture.MemberFixture;
@@ -51,13 +50,12 @@ class SeatAvailabilitySubscriptionServiceTest {
 
         SeatAvailabilitySubscriptionResponse response = seatAvailabilitySubscriptionService.create(
                 member.getId(),
-                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1)
+                request(event.getId(), schedule.getId())
         );
 
         assertThat(response.getMemberId()).isEqualTo(member.getId());
         assertThat(response.getEventId()).isEqualTo(event.getId());
         assertThat(response.getEventScheduleId()).isEqualTo(schedule.getId());
-        assertThat(response.getSeatGrade()).isEqualTo(SectionPrice.SECTION_1);
         assertThat(response.getChannel()).isEqualTo(NotificationChannel.EMAIL);
         assertThat(response.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
     }
@@ -68,7 +66,7 @@ class SeatAvailabilitySubscriptionServiceTest {
         Event event = eventPersistencePort.save(EventFixture.캣츠());
         Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
         CreateSeatAvailabilitySubscriptionRequest request =
-                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1);
+                request(event.getId(), schedule.getId());
 
         seatAvailabilitySubscriptionService.create(member.getId(), request);
 
@@ -85,7 +83,7 @@ class SeatAvailabilitySubscriptionServiceTest {
 
         SeatAvailabilitySubscriptionResponse response = seatAvailabilitySubscriptionService.create(
                 member.getId(),
-                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1)
+                request(event.getId(), schedule.getId())
         );
 
         seatAvailabilitySubscriptionService.cancel(member.getId(), response.getId());
@@ -101,7 +99,7 @@ class SeatAvailabilitySubscriptionServiceTest {
         Event event = eventPersistencePort.save(EventFixture.캣츠());
         Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
         CreateSeatAvailabilitySubscriptionRequest request =
-                request(event.getId(), schedule.getId(), SectionPrice.SECTION_1);
+                request(event.getId(), schedule.getId());
 
         SeatAvailabilitySubscriptionResponse created = seatAvailabilitySubscriptionService.create(member.getId(), request);
         seatAvailabilitySubscriptionService.cancel(member.getId(), created.getId());
@@ -114,15 +112,10 @@ class SeatAvailabilitySubscriptionServiceTest {
         assertThat(subscriptions.get(0).getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
     }
 
-    private CreateSeatAvailabilitySubscriptionRequest request(
-            Long eventId,
-            Long scheduleId,
-            SectionPrice seatGrade
-    ) {
+    private CreateSeatAvailabilitySubscriptionRequest request(Long eventId, Long scheduleId) {
         return new CreateSeatAvailabilitySubscriptionRequest(
                 eventId,
                 scheduleId,
-                seatGrade,
                 NotificationChannel.EMAIL
         );
     }

--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailableNotificationServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailableNotificationServiceTest.java
@@ -19,7 +19,6 @@ import com.noljo.nolzo.notification.repository.SeatAvailabilitySubscriptionRepos
 import com.noljo.nolzo.notification.service.SeatAvailableNotificationService;
 import com.noljo.nolzo.schedule.application.port.out.SchedulePersistencePort;
 import com.noljo.nolzo.schedule.entity.Schedule;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import com.noljo.nolzo.support.annotation.ServiceTest;
 import com.noljo.nolzo.support.fixture.EventFixture;
 import com.noljo.nolzo.support.fixture.MemberFixture;
@@ -64,7 +63,6 @@ class SeatAvailableNotificationServiceTest {
                 member.getId(),
                 event.getId(),
                 schedule.getId(),
-                SectionPrice.SECTION_1,
                 NotificationChannel.EMAIL,
                 SubscriptionStatus.ACTIVE
         ));

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadSeatAvailabilitySubscriptionPort.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadSeatAvailabilitySubscriptionPort.java
@@ -3,7 +3,6 @@ package com.noljo.nolzo.notification.application.port.out;
 import com.noljo.nolzo.notification.domain.NotificationChannel;
 import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,19 +12,17 @@ public interface LoadSeatAvailabilitySubscriptionPort {
             Long memberId,
             Long eventId,
             Long eventScheduleId,
-            SectionPrice seatGrade,
             NotificationChannel channel
     );
 
-    List<SeatAvailabilitySubscription> findAllByMemberIdAndStatus(
+    List<SeatAvailabilitySubscription> findMemberSubscriptions(
             Long memberId,
             SubscriptionStatus status
     );
 
-    List<SeatAvailabilitySubscription> findAllByEventScheduleSeatGradeAndStatusAndChannel(
+    List<SeatAvailabilitySubscription> findTargetSubscriptions(
             Long eventId,
             Long eventScheduleId,
-            SectionPrice seatGrade,
             SubscriptionStatus status,
             NotificationChannel channel
     );

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/SeatAvailabilitySubscription.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/domain/SeatAvailabilitySubscription.java
@@ -1,7 +1,6 @@
 package com.noljo.nolzo.notification.domain;
 
 import com.noljo.nolzo.global.BaseEntity;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -23,8 +22,8 @@ import lombok.NoArgsConstructor;
         name = "seat_availability_subscription",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uk_subscription_member_event_schedule_grade_channel",
-                        columnNames = {"member_id", "event_id", "event_schedule_id", "seat_grade", "channel"}
+                        name = "uk_subscription_member_event_schedule_channel",
+                        columnNames = {"member_id", "event_id", "event_schedule_id", "channel"}
                 )
         }
 )
@@ -45,10 +44,6 @@ public class SeatAvailabilitySubscription extends BaseEntity {
     private Long eventScheduleId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "seat_grade", nullable = false)
-    private SectionPrice seatGrade;
-
-    @Enumerated(EnumType.STRING)
     @Column(name = "channel", nullable = false)
     private NotificationChannel channel;
 
@@ -63,14 +58,12 @@ public class SeatAvailabilitySubscription extends BaseEntity {
             Long memberId,
             Long eventId,
             Long eventScheduleId,
-            SectionPrice seatGrade,
             NotificationChannel channel,
             SubscriptionStatus status
     ) {
         this.memberId = memberId;
         this.eventId = eventId;
         this.eventScheduleId = eventScheduleId;
-        this.seatGrade = seatGrade;
         this.channel = channel;
         this.status = status;
     }

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/CreateSeatAvailabilitySubscriptionRequest.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/CreateSeatAvailabilitySubscriptionRequest.java
@@ -1,12 +1,10 @@
 package com.noljo.nolzo.notification.dto;
 
 import com.noljo.nolzo.notification.domain.NotificationChannel;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 
 public record CreateSeatAvailabilitySubscriptionRequest(
         Long eventId,
         Long eventScheduleId,
-        SectionPrice seatGrade,
         NotificationChannel channel
 ) {
 }

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/SeatAvailabilitySubscriptionResponse.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/dto/SeatAvailabilitySubscriptionResponse.java
@@ -3,7 +3,6 @@ package com.noljo.nolzo.notification.dto;
 import com.noljo.nolzo.notification.domain.NotificationChannel;
 import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +15,6 @@ public class SeatAvailabilitySubscriptionResponse {
     private Long memberId;
     private Long eventId;
     private Long eventScheduleId;
-    private SectionPrice seatGrade;
     private NotificationChannel channel;
     private SubscriptionStatus status;
     private LocalDateTime lastNotifiedAt;
@@ -28,7 +26,6 @@ public class SeatAvailabilitySubscriptionResponse {
                 .memberId(subscription.getMemberId())
                 .eventId(subscription.getEventId())
                 .eventScheduleId(subscription.getEventScheduleId())
-                .seatGrade(subscription.getSeatGrade())
                 .channel(subscription.getChannel())
                 .status(subscription.getStatus())
                 .lastNotifiedAt(subscription.getLastNotifiedAt())

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailabilitySubscriptionService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailabilitySubscriptionService.java
@@ -44,7 +44,6 @@ public class SeatAvailabilitySubscriptionService implements
                         memberId,
                         request.eventId(),
                         request.eventScheduleId(),
-                        request.seatGrade(),
                         request.channel()
                 )
                 .orElse(null);
@@ -64,7 +63,6 @@ public class SeatAvailabilitySubscriptionService implements
                 memberId,
                 request.eventId(),
                 request.eventScheduleId(),
-                request.seatGrade(),
                 request.channel(),
                 SubscriptionStatus.ACTIVE
         );
@@ -91,7 +89,7 @@ public class SeatAvailabilitySubscriptionService implements
 
     @Override
     public List<SeatAvailabilitySubscriptionResponse> readAllByMemberId(Long memberId) {
-        return loadSeatAvailabilitySubscriptionPort.findAllByMemberIdAndStatus(
+        return loadSeatAvailabilitySubscriptionPort.findMemberSubscriptions(
                         memberId,
                         SubscriptionStatus.ACTIVE
                 ).stream()

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailableNotificationService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailableNotificationService.java
@@ -10,11 +10,9 @@ import com.noljo.nolzo.notification.application.port.out.SaveNotificationDeliver
 import com.noljo.nolzo.notification.application.port.out.SendEmailNotificationPort;
 import com.noljo.nolzo.notification.domain.NotificationChannel;
 import com.noljo.nolzo.notification.domain.NotificationDelivery;
-import com.noljo.nolzo.notification.domain.NotificationDeliveryStatus;
 import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
 import com.noljo.nolzo.notification.domain.event.SeatAvailableEvent;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,16 +31,12 @@ public class SeatAvailableNotificationService implements HandleSeatAvailableUseC
     @Override
     @Transactional
     public void handle(SeatAvailableEvent event) {
-        SectionPrice seatGrade = resolveSeatGrade(event.seatGrade());
-
-        List<SeatAvailabilitySubscription> subscriptions =
-                loadSeatAvailabilitySubscriptionPort.findAllByEventScheduleSeatGradeAndStatusAndChannel(
-                        event.eventId(),
-                        event.eventScheduleId(),
-                        seatGrade,
-                        SubscriptionStatus.ACTIVE,
-                        NotificationChannel.EMAIL
-                );
+        List<SeatAvailabilitySubscription> subscriptions = loadSeatAvailabilitySubscriptionPort.findTargetSubscriptions(
+                event.eventId(),
+                event.eventScheduleId(),
+                SubscriptionStatus.ACTIVE,
+                NotificationChannel.EMAIL
+        );
 
         if (subscriptions.isEmpty()) {
             return;
@@ -60,41 +54,58 @@ public class SeatAvailableNotificationService implements HandleSeatAvailableUseC
             Event targetEvent,
             SeatAvailabilitySubscription subscription
     ) {
-        Member member = memberPersistencePort.getOrThrow(subscription.getMemberId());
-        String recipient = member.getEmail();
-
+        String recipient = getRecipient(subscription);
         try {
             sendEmailNotificationPort.send(
                     recipient,
                     createSubject(targetEvent),
                     createBody(targetEvent, event)
             );
-
-            subscription.updateLastNotifiedAt(event.availableAt());
-            NotificationDelivery delivery = new NotificationDelivery(
-                    subscription.getId(),
-                    subscription.getMemberId(),
-                    event.eventId(),
-                    event.eventScheduleId(),
-                    event.seatGrade(),
-                    subscription.getChannel(),
-                    recipient,
-                    event.availableAt()
-            );
-            saveNotificationDeliveryPort.save(delivery);
+            saveSuccess(event, subscription, recipient);
         } catch (Exception e) {
-            NotificationDelivery delivery = new NotificationDelivery(
-                    subscription.getId(),
-                    subscription.getMemberId(),
-                    event.eventId(),
-                    event.eventScheduleId(),
-                    event.seatGrade(),
-                    subscription.getChannel(),
-                    recipient,
-                    e.getMessage()
-            );
-            saveNotificationDeliveryPort.save(delivery);
+            saveFailure(event, subscription, recipient, e.getMessage());
         }
+    }
+
+    private String getRecipient(SeatAvailabilitySubscription subscription) {
+        Member member = memberPersistencePort.getOrThrow(subscription.getMemberId());
+        return member.getEmail();
+    }
+
+    private void saveSuccess(
+            SeatAvailableEvent event,
+            SeatAvailabilitySubscription subscription,
+            String recipient
+    ) {
+        subscription.updateLastNotifiedAt(event.availableAt());
+        saveNotificationDeliveryPort.save(new NotificationDelivery(
+                subscription.getId(),
+                subscription.getMemberId(),
+                event.eventId(),
+                event.eventScheduleId(),
+                event.seatGrade(),
+                subscription.getChannel(),
+                recipient,
+                event.availableAt()
+        ));
+    }
+
+    private void saveFailure(
+            SeatAvailableEvent event,
+            SeatAvailabilitySubscription subscription,
+            String recipient,
+            String failureReason
+    ) {
+        saveNotificationDeliveryPort.save(new NotificationDelivery(
+                subscription.getId(),
+                subscription.getMemberId(),
+                event.eventId(),
+                event.eventScheduleId(),
+                event.seatGrade(),
+                subscription.getChannel(),
+                recipient,
+                failureReason
+        ));
     }
 
     private String createSubject(Event event) {
@@ -112,16 +123,5 @@ public class SeatAvailableNotificationService implements HandleSeatAvailableUseC
                 seatAvailableEvent.eventScheduleId(),
                 seatAvailableEvent.seatGrade()
         );
-    }
-
-    private SectionPrice resolveSeatGrade(String seatGrade) {
-        return switch (seatGrade) {
-            case "1구역" -> SectionPrice.SECTION_1;
-            case "2구역" -> SectionPrice.SECTION_2;
-            case "3구역" -> SectionPrice.SECTION_3;
-            case "4구역" -> SectionPrice.SECTION_4;
-            case "5구역" -> SectionPrice.SECTION_5;
-            default -> throw new IllegalArgumentException("알 수 없는 좌석 등급입니다: " + seatGrade);
-        };
     }
 }

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/SeatAvailabilitySubscriptionPersistenceAdapter.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/SeatAvailabilitySubscriptionPersistenceAdapter.java
@@ -6,7 +6,6 @@ import com.noljo.nolzo.notification.domain.NotificationChannel;
 import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
 import com.noljo.nolzo.notification.repository.SeatAvailabilitySubscriptionRepository;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -30,41 +29,37 @@ public class SeatAvailabilitySubscriptionPersistenceAdapter implements
             Long memberId,
             Long eventId,
             Long eventScheduleId,
-            SectionPrice seatGrade,
             NotificationChannel channel
     ) {
         return seatAvailabilitySubscriptionRepository.findExistingSubscription(
                 memberId,
                 eventId,
                 eventScheduleId,
-                seatGrade,
                 channel
         );
     }
 
     @Override
-    public List<SeatAvailabilitySubscription> findAllByMemberIdAndStatus(
+    public List<SeatAvailabilitySubscription> findMemberSubscriptions(
             Long memberId,
             SubscriptionStatus status
     ) {
-        return seatAvailabilitySubscriptionRepository.findAllByMemberIdAndStatus(
+        return seatAvailabilitySubscriptionRepository.findMemberSubscriptions(
                 memberId,
                 status
         );
     }
 
     @Override
-    public List<SeatAvailabilitySubscription> findAllByEventScheduleSeatGradeAndStatusAndChannel(
+    public List<SeatAvailabilitySubscription> findTargetSubscriptions(
             Long eventId,
             Long eventScheduleId,
-            SectionPrice seatGrade,
             SubscriptionStatus status,
             NotificationChannel channel
     ) {
-        return seatAvailabilitySubscriptionRepository.findAllByEventScheduleSeatGradeAndStatusAndChannel(
+        return seatAvailabilitySubscriptionRepository.findTargetSubscriptions(
                 eventId,
                 eventScheduleId,
-                seatGrade,
                 status,
                 channel
         );

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/SeatAvailabilitySubscriptionRepository.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/SeatAvailabilitySubscriptionRepository.java
@@ -3,7 +3,6 @@ package com.noljo.nolzo.notification.repository;
 import com.noljo.nolzo.notification.domain.NotificationChannel;
 import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
-import com.noljo.nolzo.seat.entity.SectionPrice;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,14 +17,12 @@ public interface SeatAvailabilitySubscriptionRepository extends JpaRepository<Se
             where s.memberId = :memberId
               and s.eventId = :eventId
               and s.eventScheduleId = :eventScheduleId
-              and s.seatGrade = :seatGrade
               and s.channel = :channel
             """)
     Optional<SeatAvailabilitySubscription> findExistingSubscription(
             @Param("memberId") Long memberId,
             @Param("eventId") Long eventId,
             @Param("eventScheduleId") Long eventScheduleId,
-            @Param("seatGrade") SectionPrice seatGrade,
             @Param("channel") NotificationChannel channel
     );
 
@@ -36,7 +33,7 @@ public interface SeatAvailabilitySubscriptionRepository extends JpaRepository<Se
               and s.status = :status
             order by s.createdAt desc
             """)
-    List<SeatAvailabilitySubscription> findAllByMemberIdAndStatus(
+    List<SeatAvailabilitySubscription> findMemberSubscriptions(
             @Param("memberId") Long memberId,
             @Param("status") SubscriptionStatus status
     );
@@ -46,15 +43,13 @@ public interface SeatAvailabilitySubscriptionRepository extends JpaRepository<Se
             from SeatAvailabilitySubscription s
             where s.eventId = :eventId
               and s.eventScheduleId = :eventScheduleId
-              and s.seatGrade = :seatGrade
               and s.status = :status
               and s.channel = :channel
             order by s.createdAt asc
             """)
-    List<SeatAvailabilitySubscription> findAllByEventScheduleSeatGradeAndStatusAndChannel(
+    List<SeatAvailabilitySubscription> findTargetSubscriptions(
             @Param("eventId") Long eventId,
             @Param("eventScheduleId") Long eventScheduleId,
-            @Param("seatGrade") SectionPrice seatGrade,
             @Param("status") SubscriptionStatus status,
             @Param("channel") NotificationChannel channel
     );


### PR DESCRIPTION
## 📌 개요

* 빈자리 알림 구독 조건을 기존 `공연 + 회차 + 좌석등급 + 채널` 기준에서 `공연 + 회차 + 채널` 기준으로 단순화했습니다.
* 이를 통해 사용자가 특정 회차 자체에 관심이 있는 경우, 어떤 좌석이 취소되더라도 빈자리 알림을 받을 수 있도록 알림 정책을 변경했습니다.
* 알림 처리 로직도 이번 요구사항에 맞춰 단순한 1차 흐름으로 정리했습니다.

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#27`)

### 구독 조건 단순화

* `SeatAvailabilitySubscription`에서 `seatGrade` 필드를 제거했습니다.
* 구독 생성 요청/응답 DTO에서도 좌석등급 필드를 제거했습니다.
* 구독의 유니크 조건을 `member + event + schedule + channel` 기준으로 변경했습니다.
* 동일한 공연/회차에 대해 사용자는 채널 기준으로만 구독 여부가 판단되도록 수정했습니다.

### 알림 대상 조회 조건 변경

* 알림 발송 시 구독자 조회 조건에서 좌석등급을 제거했습니다.
* 이제 특정 공연/회차에 빈자리 이벤트가 발생하면, 해당 공연/회차를 구독한 사용자에게 알림이 가도록 변경했습니다.
* 이벤트 내부의 `seatGrade` 정보는 더 이상 구독 매칭 조건이 아니라, 알림 본문에 어떤 좌석이 비었는지 보여주기 위한 정보로만 사용됩니다.

### 알림 처리 로직 단순화

* 이번 PR에서는 알림 흐름을 우선 단순하게 유지하는 방향으로 정리했습니다.
* Kafka consumer가 이벤트를 수신하면:
  - 해당 공연/회차 구독자 조회
  - 이메일 발송 포트 호출
  - 발송 성공/실패 이력 저장
  의 기본 흐름만 수행하도록 구성했습니다.

## 📌 retry / batch / dedup 등을 이번 PR에서 제외한 이유

* 이전 이슈에서 대량 처리와 안정화를 위한 `retry`, `batch 처리`, `중복 발송 방지`, `cooldown` 등을 함께 고려했지만, 이번 변경의 핵심 요구사항은 **“좌석등급과 무관하게 공연/회차 기준으로 알림을 받고 싶다”**는 정책 변경이었습니다.
* 그래서 이번 PR에서는 먼저 **구독 기준과 알림 매칭 정책을 단순하고 명확하게 바꾸는 것**에 집중했습니다.
* `retry`, `batch`, `dedup`, `cooldown`은 기능이 동작한 이후의 **대량 처리/운영 안정화 이슈**로 분리해서 후속 작업에서 다루는 것이 더 적절하다고 판단했습니다.

## 📌 차후 계획 (Optional)

* 다음 단계에서는 대량 구독자 환경을 고려해 batch 처리, retry, dedup, cooldown 같은 안정화 요소를 별도 이슈로 확장할 예정입니다.
* 실제 이메일 발송 구현이 필요해지면 현재 logging 기반 adapter를 SMTP/외부 메일 서비스 연동 방식으로 교체할 계획입니다.
* 이후에는 알림 실패 재처리, dead-letter, 모니터링 지표까지 포함한 운영 안정화 작업으로 이어갈 예정입니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

* 구독 서비스 테스트를 통해:
  - 공연/회차 기준 구독 생성
  - 동일 조건 중복 구독 예외
  - 구독 해지
  - 해지 후 재구독 시 재활성화
  를 확인했습니다.
* 알림 서비스 테스트를 통해:
  - 해당 공연/회차 구독자에게 알림 발송
  - 구독자가 없을 경우 이력 미생성
  을 확인했습니다.
* 전체 빌드를 실행해 멀티모듈 환경에서 컴파일 및 테스트가 정상 통과하는지 확인했습니다.

close: #27 