### PR TITLE
[Feature] 알림 대량 전송처리 및 안정화 구현

### DIFF
--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailableNotificationServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/notification/service/SeatAvailableNotificationServiceTest.java
@@ -1,6 +1,9 @@
 package com.noljo.nolzo.domain.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.noljo.nolzo.event.application.port.out.EventPersistencePort;
@@ -28,6 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ServiceTest
 class SeatAvailableNotificationServiceTest {
@@ -108,5 +112,102 @@ class SeatAvailableNotificationServiceTest {
         ));
 
         assertThat(notificationDeliveryRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void 동일한_이벤트가_재처리되어도_중복_발송하지_않는다() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+
+        seatAvailabilitySubscriptionRepository.save(new SeatAvailabilitySubscription(
+                member.getId(),
+                event.getId(),
+                schedule.getId(),
+                NotificationChannel.EMAIL,
+                SubscriptionStatus.ACTIVE
+        ));
+
+        SeatAvailableEvent seatAvailableEvent = new SeatAvailableEvent(
+                event.getId(),
+                schedule.getId(),
+                100L,
+                "1구역",
+                LocalDateTime.of(2026, 4, 26, 12, 0)
+        );
+
+        seatAvailableNotificationService.handle(seatAvailableEvent);
+        seatAvailableNotificationService.handle(seatAvailableEvent);
+
+        verify(sendEmailNotificationPort, times(1)).send(anyString(), anyString(), anyString());
+        assertThat(notificationDeliveryRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void 배치_크기보다_구독자가_많아도_나누어_처리한다() {
+        ReflectionTestUtils.setField(seatAvailableNotificationService, "batchSize", 1);
+
+        Member first = memberPersistencePort.save(MemberFixture.회원());
+        Member second = memberPersistencePort.save(MemberFixture.회투());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+
+        seatAvailabilitySubscriptionRepository.save(new SeatAvailabilitySubscription(
+                first.getId(),
+                event.getId(),
+                schedule.getId(),
+                NotificationChannel.EMAIL,
+                SubscriptionStatus.ACTIVE
+        ));
+        seatAvailabilitySubscriptionRepository.save(new SeatAvailabilitySubscription(
+                second.getId(),
+                event.getId(),
+                schedule.getId(),
+                NotificationChannel.EMAIL,
+                SubscriptionStatus.ACTIVE
+        ));
+
+        seatAvailableNotificationService.handle(new SeatAvailableEvent(
+                event.getId(),
+                schedule.getId(),
+                100L,
+                "1구역",
+                LocalDateTime.of(2026, 4, 26, 12, 0)
+        ));
+
+        verify(sendEmailNotificationPort, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(notificationDeliveryRepository.findAll()).hasSize(2);
+    }
+
+    @Test
+    void 이메일_발송에_실패하면_설정된_횟수만큼_재시도한다() {
+        Member member = memberPersistencePort.save(MemberFixture.회원());
+        Event event = eventPersistencePort.save(EventFixture.캣츠());
+        Schedule schedule = schedulePersistencePort.save(ScheduleFixture.공연_스케쥴(event));
+
+        seatAvailabilitySubscriptionRepository.save(new SeatAvailabilitySubscription(
+                member.getId(),
+                event.getId(),
+                schedule.getId(),
+                NotificationChannel.EMAIL,
+                SubscriptionStatus.ACTIVE
+        ));
+
+        doThrow(new RuntimeException("mail send failed"))
+                .when(sendEmailNotificationPort)
+                .send(anyString(), anyString(), anyString());
+
+        seatAvailableNotificationService.handle(new SeatAvailableEvent(
+                event.getId(),
+                schedule.getId(),
+                100L,
+                "1구역",
+                LocalDateTime.of(2026, 4, 26, 12, 0)
+        ));
+
+        verify(sendEmailNotificationPort, times(3)).send(anyString(), anyString(), anyString());
+        assertThat(notificationDeliveryRepository.findAll()).hasSize(1);
+        assertThat(notificationDeliveryRepository.findAll().get(0).getStatus())
+                .isEqualTo(NotificationDeliveryStatus.FAILED);
     }
 }

--- a/nolzo-api/src/test/resources/application-test.yml
+++ b/nolzo-api/src/test/resources/application-test.yml
@@ -50,3 +50,7 @@ app:
       group-id: test-seat-available-group
     topics:
       seat-available: seat-available-events
+  notification:
+    batch-size: 2
+    cooldown-minutes: 10
+    retry-attempts: 3

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadNotificationDeliveryPort.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadNotificationDeliveryPort.java
@@ -1,0 +1,8 @@
+package com.noljo.nolzo.notification.application.port.out;
+
+import java.time.LocalDateTime;
+
+public interface LoadNotificationDeliveryPort {
+
+    boolean hasSentHistory(Long subscriptionId, LocalDateTime sentAt);
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadSeatAvailabilitySubscriptionPort.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/application/port/out/LoadSeatAvailabilitySubscriptionPort.java
@@ -24,7 +24,9 @@ public interface LoadSeatAvailabilitySubscriptionPort {
             Long eventId,
             Long eventScheduleId,
             SubscriptionStatus status,
-            NotificationChannel channel
+            NotificationChannel channel,
+            int page,
+            int size
     );
 
     Optional<SeatAvailabilitySubscription> findByIdAndMemberId(Long id, Long memberId);

--- a/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailableNotificationService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/notification/service/SeatAvailableNotificationService.java
@@ -5,6 +5,7 @@ import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.member.application.port.out.MemberPersistencePort;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.notification.application.port.in.HandleSeatAvailableUseCase;
+import com.noljo.nolzo.notification.application.port.out.LoadNotificationDeliveryPort;
 import com.noljo.nolzo.notification.application.port.out.LoadSeatAvailabilitySubscriptionPort;
 import com.noljo.nolzo.notification.application.port.out.SaveNotificationDeliveryPort;
 import com.noljo.nolzo.notification.application.port.out.SendEmailNotificationPort;
@@ -14,8 +15,10 @@ import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
 import com.noljo.nolzo.notification.domain.event.SeatAvailableEvent;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,30 +26,59 @@ import org.springframework.stereotype.Service;
 public class SeatAvailableNotificationService implements HandleSeatAvailableUseCase {
 
     private final LoadSeatAvailabilitySubscriptionPort loadSeatAvailabilitySubscriptionPort;
+    private final LoadNotificationDeliveryPort loadNotificationDeliveryPort;
     private final SaveNotificationDeliveryPort saveNotificationDeliveryPort;
     private final SendEmailNotificationPort sendEmailNotificationPort;
     private final MemberPersistencePort memberPersistencePort;
     private final EventPersistencePort eventPersistencePort;
 
+    @Value("${app.notification.batch-size:100}")
+    private int batchSize;
+
+    @Value("${app.notification.cooldown-minutes:10}")
+    private int cooldownMinutes;
+
+    @Value("${app.notification.retry-attempts:3}")
+    private int retryAttempts;
+
     @Override
     @Transactional
     public void handle(SeatAvailableEvent event) {
-        List<SeatAvailabilitySubscription> subscriptions = loadSeatAvailabilitySubscriptionPort.findTargetSubscriptions(
+        Event targetEvent = eventPersistencePort.getOrThrow(event.eventId());
+        processBatches(event, targetEvent);
+    }
+
+    private void processBatches(SeatAvailableEvent event, Event targetEvent) {
+        int page = 0;
+
+        while (true) {
+            List<SeatAvailabilitySubscription> subscriptions = loadSubscriptions(event, page);
+
+            if (subscriptions.isEmpty()) {
+                return;
+            }
+
+            for (SeatAvailabilitySubscription subscription : subscriptions) {
+                sendEmail(event, targetEvent, subscription);
+            }
+
+            if (subscriptions.size() < batchSize) {
+                return;
+            }
+
+            page++;
+        }
+    }
+
+    private List<SeatAvailabilitySubscription> loadSubscriptions(SeatAvailableEvent event, int page) {
+        return loadSeatAvailabilitySubscriptionPort.findTargetSubscriptions(
                 event.eventId(),
                 event.eventScheduleId(),
                 SubscriptionStatus.ACTIVE,
-                NotificationChannel.EMAIL
+                NotificationChannel.EMAIL,
+                page,
+                batchSize
         );
-
-        if (subscriptions.isEmpty()) {
-            return;
-        }
-
-        Event targetEvent = eventPersistencePort.getOrThrow(event.eventId());
-
-        for (SeatAvailabilitySubscription subscription : subscriptions) {
-            sendEmail(event, targetEvent, subscription);
-        }
     }
 
     private void sendEmail(
@@ -54,22 +86,47 @@ public class SeatAvailableNotificationService implements HandleSeatAvailableUseC
             Event targetEvent,
             SeatAvailabilitySubscription subscription
     ) {
-        String recipient = getRecipient(subscription);
-        try {
-            sendEmailNotificationPort.send(
-                    recipient,
-                    createSubject(targetEvent),
-                    createBody(targetEvent, event)
-            );
-            saveSuccess(event, subscription, recipient);
-        } catch (Exception e) {
-            saveFailure(event, subscription, recipient, e.getMessage());
+        if (shouldSkipNotification(subscription, event.availableAt())) {
+            return;
         }
+
+        String recipient = getRecipient(subscription);
+        SendResult result = sendWithRetry(recipient, targetEvent, event);
+
+        if (result.isSuccess()) {
+            saveSuccess(event, subscription, recipient);
+            return;
+        }
+
+        saveFailure(event, subscription, recipient, result.failureReason());
     }
 
     private String getRecipient(SeatAvailabilitySubscription subscription) {
         Member member = memberPersistencePort.getOrThrow(subscription.getMemberId());
         return member.getEmail();
+    }
+
+    private boolean shouldSkipNotification(SeatAvailabilitySubscription subscription, LocalDateTime availableAt) {
+        return alreadySent(subscription, availableAt) || isCooldownActive(subscription, availableAt);
+    }
+
+    private SendResult sendWithRetry(String recipient, Event targetEvent, SeatAvailableEvent event) {
+        Exception failure = null;
+
+        for (int attempt = 0; attempt < retryAttempts; attempt++) {
+            try {
+                sendEmailNotificationPort.send(
+                        recipient,
+                        createSubject(targetEvent),
+                        createBody(targetEvent, event)
+                );
+                return SendResult.sent();
+            } catch (Exception e) {
+                failure = e;
+            }
+        }
+
+        return SendResult.failed(failure == null ? "알 수 없는 발송 실패" : failure.getMessage());
     }
 
     private void saveSuccess(
@@ -108,6 +165,20 @@ public class SeatAvailableNotificationService implements HandleSeatAvailableUseC
         ));
     }
 
+    private boolean alreadySent(SeatAvailabilitySubscription subscription, LocalDateTime availableAt) {
+        return loadNotificationDeliveryPort.hasSentHistory(subscription.getId(), availableAt);
+    }
+
+    private boolean isCooldownActive(SeatAvailabilitySubscription subscription, LocalDateTime availableAt) {
+        LocalDateTime lastNotifiedAt = subscription.getLastNotifiedAt();
+
+        if (lastNotifiedAt == null) {
+            return false;
+        }
+
+        return !availableAt.isAfter(lastNotifiedAt.plusMinutes(cooldownMinutes));
+    }
+
     private String createSubject(Event event) {
         return "[NOLZO] " + event.getTitle() + " 빈자리가 발생했습니다.";
     }
@@ -123,5 +194,20 @@ public class SeatAvailableNotificationService implements HandleSeatAvailableUseC
                 seatAvailableEvent.eventScheduleId(),
                 seatAvailableEvent.seatGrade()
         );
+    }
+
+    private record SendResult(boolean success, String failureReason) {
+
+        private boolean isSuccess() {
+            return success;
+        }
+
+        private static SendResult sent() {
+            return new SendResult(true, null);
+        }
+
+        private static SendResult failed(String failureReason) {
+            return new SendResult(false, failureReason);
+        }
     }
 }

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/NotificationDeliveryPersistenceAdapter.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/NotificationDeliveryPersistenceAdapter.java
@@ -1,19 +1,31 @@
 package com.noljo.nolzo.notification.adapter.out.persistence;
 
+import com.noljo.nolzo.notification.application.port.out.LoadNotificationDeliveryPort;
 import com.noljo.nolzo.notification.application.port.out.SaveNotificationDeliveryPort;
 import com.noljo.nolzo.notification.domain.NotificationDelivery;
+import com.noljo.nolzo.notification.domain.NotificationDeliveryStatus;
 import com.noljo.nolzo.notification.repository.NotificationDeliveryRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class NotificationDeliveryPersistenceAdapter implements SaveNotificationDeliveryPort {
+public class NotificationDeliveryPersistenceAdapter implements SaveNotificationDeliveryPort, LoadNotificationDeliveryPort {
 
     private final NotificationDeliveryRepository notificationDeliveryRepository;
 
     @Override
     public NotificationDelivery save(NotificationDelivery notificationDelivery) {
         return notificationDeliveryRepository.save(notificationDelivery);
+    }
+
+    @Override
+    public boolean hasSentHistory(Long subscriptionId, LocalDateTime sentAt) {
+        return notificationDeliveryRepository.existsSentHistory(
+                subscriptionId,
+                NotificationDeliveryStatus.SENT,
+                sentAt
+        );
     }
 }

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/SeatAvailabilitySubscriptionPersistenceAdapter.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/adapter/out/persistence/SeatAvailabilitySubscriptionPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.noljo.nolzo.notification.repository.SeatAvailabilitySubscriptionRepos
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -55,13 +56,16 @@ public class SeatAvailabilitySubscriptionPersistenceAdapter implements
             Long eventId,
             Long eventScheduleId,
             SubscriptionStatus status,
-            NotificationChannel channel
+            NotificationChannel channel,
+            int page,
+            int size
     ) {
         return seatAvailabilitySubscriptionRepository.findTargetSubscriptions(
                 eventId,
                 eventScheduleId,
                 status,
-                channel
+                channel,
+                PageRequest.of(page, size)
         );
     }
 

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/NotificationDeliveryRepository.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/NotificationDeliveryRepository.java
@@ -1,7 +1,24 @@
 package com.noljo.nolzo.notification.repository;
 
 import com.noljo.nolzo.notification.domain.NotificationDelivery;
+import com.noljo.nolzo.notification.domain.NotificationDeliveryStatus;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationDeliveryRepository extends JpaRepository<NotificationDelivery, Long> {
+
+    @Query("""
+            select count(d) > 0
+            from NotificationDelivery d
+            where d.subscriptionId = :subscriptionId
+              and d.status = :status
+              and d.sentAt = :sentAt
+            """)
+    boolean existsSentHistory(
+            @Param("subscriptionId") Long subscriptionId,
+            @Param("status") NotificationDeliveryStatus status,
+            @Param("sentAt") LocalDateTime sentAt
+    );
 }

--- a/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/SeatAvailabilitySubscriptionRepository.java
+++ b/nolzo-infra/src/main/java/com/noljo/nolzo/notification/repository/SeatAvailabilitySubscriptionRepository.java
@@ -5,6 +5,7 @@ import com.noljo.nolzo.notification.domain.SeatAvailabilitySubscription;
 import com.noljo.nolzo.notification.domain.SubscriptionStatus;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -51,7 +52,8 @@ public interface SeatAvailabilitySubscriptionRepository extends JpaRepository<Se
             @Param("eventId") Long eventId,
             @Param("eventScheduleId") Long eventScheduleId,
             @Param("status") SubscriptionStatus status,
-            @Param("channel") NotificationChannel channel
+            @Param("channel") NotificationChannel channel,
+            Pageable pageable
     );
 
     Optional<SeatAvailabilitySubscription> findByIdAndMemberId(Long id, Long memberId);


### PR DESCRIPTION
## 📌 개요

* 빈자리 알림 기능이 대량 구독자 환경에서도 보다 안정적으로 동작할 수 있도록 알림 처리 로직을 고도화했습니다.
* 공연/회차 기준 구독 모델 위에서 구독자 batch 조회, 중복 발송 방지, cooldown, 재시도 로직을 추가하고 관련 테스트를 보강했습니다.

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#29`)

### 알림 대상 조회 구조 개선

* 기존에는 빈자리 이벤트 수신 시 대상 구독자를 한 번에 조회하는 단순 흐름이었습니다.
* 이번 PR에서는 구독자 조회를 `page + size` 기반으로 확장해 batch 단위로 처리할 수 있도록 변경했습니다.
* 이를 위해 `LoadSeatAvailabilitySubscriptionPort`, `SeatAvailabilitySubscriptionPersistenceAdapter`, `SeatAvailabilitySubscriptionRepository`를 수정해 공연/회차/채널 기준의 구독자를 페이지 단위로 조회할 수 있도록 반영했습니다.

### 발송 이력 조회 포트 추가

* 중복 발송 방지를 위해 `LoadNotificationDeliveryPort`를 새로 추가했습니다.
* `NotificationDeliveryRepository`에는 성공 발송 이력 존재 여부를 조회하는 쿼리를 추가했고, `NotificationDeliveryPersistenceAdapter`가 이를 구현하도록 확장했습니다.
* 이를 통해 동일한 구독자에게 같은 이벤트 시점의 알림을 다시 보내지 않도록 제어할 수 있게 했습니다.

### 알림 서비스 안정화 로직 추가

* `SeatAvailableNotificationService`에 다음 안정화 로직을 추가했습니다.
  - batch 단위 구독자 처리
  - 동일 이벤트 재처리 시 중복 발송 방지
  - `lastNotifiedAt` 기반 cooldown 적용
  - 메일 발송 실패 시 재시도
* 메일 발송 결과는 `SendResult`로 명확하게 나누어 성공/실패 흐름이 더 읽기 쉽게 정리되도록 했습니다.
* 성공 시에는 기존과 동일하게 `NotificationDelivery`를 `SENT` 상태로 저장하고, 실패 시에는 최종 실패 사유를 포함해 `FAILED` 상태로 저장합니다.

### 테스트 보강

* `SeatAvailableNotificationServiceTest`를 보강해 다음 시나리오를 검증했습니다.
  - 동일 이벤트 재처리 시 중복 발송 방지
  - batch 크기보다 구독자가 많을 때 분할 처리
  - 메일 발송 실패 시 설정된 횟수만큼 재시도 후 실패 이력 저장
* `application-test.yml`에는 `batch-size`, `cooldown-minutes`, `retry-attempts` 테스트 설정을 추가해 테스트가 의도대로 동작하도록 했습니다.

## 📌 이번 PR이 대용량 처리와 관련 있는 이유

* 이번 변경은 단순히 알림이 동작하도록 만드는 작업이 아니라, **구독자가 많고 이벤트가 반복적으로 들어오는 상황에서도 시스템이 버틸 수 있도록** 만드는 1차 안정화 작업입니다.
* 구독자를 batch 단위로 조회하도록 바꾸면서 한 번에 전체 대상을 메모리에 올리는 부담을 줄였고,
* 같은 이벤트 재처리 시 중복 발송을 막아 불필요한 발송량 폭증을 방지했으며,
* cooldown으로 짧은 시간 안의 과도한 재알림을 줄이고,
* retry를 통해 대량 발송 중 일시적인 실패가 바로 유실되지 않도록 보완했습니다.

## 📌 차후 계획 (Optional)

* 다음 단계에서는 실제 메일 서버(SMTP/SES 등)와 연동해 현재 logging 기반 이메일 발송을 실제 발송 구현으로 교체할 예정입니다.
* 이후에는 dead-letter 처리, batch fan-out, outbox 패턴, 모니터링 지표 추가 등 운영 안정화를 위한 후속 작업을 진행할 계획입니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

* `SeatAvailableNotificationServiceTest`
  - 구독자에게 정상 발송 및 `SENT` 이력 저장
  - 구독자가 없을 경우 이력 미생성
  - 동일 이벤트 재처리 시 1회만 발송
  - batch 단위 분할 처리
  - 메일 실패 시 3회 재시도 후 `FAILED` 이력 저장
* 전체 빌드를 실행해 멀티모듈 환경에서 컴파일 및 테스트가 정상 통과하는지 확인했습니다.

close: #29 
