### PR TITLE
[Feature] 사용자 맞춤 공연 탐색 도우미 API구현

### DIFF
--- a/nolzo-api/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/nolzo-api/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -2,6 +2,8 @@ package com.noljo.nolzo.event.controller;
 
 import com.noljo.nolzo.auth.security.CustomUserDetails;
 import com.noljo.nolzo.event.dto.EventRequest;
+import com.noljo.nolzo.event.dto.EventRecommendRequest;
+import com.noljo.nolzo.event.dto.EventRecommendResponse;
 import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.entity.EventCategory;
@@ -63,6 +65,13 @@ public class EventController {
     @GetMapping("/popular")
     public ResponseEntity<List<EventResponse>> getTop6PopularEvents() {
         return ResponseEntity.ok(eventUseCase.getTop6PopularEvents());
+    }
+
+    @PostMapping("/recommend")
+    public ResponseEntity<EventRecommendResponse> recommendEvents(
+            @RequestBody @Valid EventRecommendRequest request
+    ) {
+        return ResponseEntity.ok(eventUseCase.recommendEvents(request));
     }
 
     @PatchMapping(value = "/{id}",

--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -1,6 +1,8 @@
 package com.noljo.nolzo.domain.event.service;
 
 import com.noljo.nolzo.event.dto.EventRequest;
+import com.noljo.nolzo.event.dto.EventRecommendRequest;
+import com.noljo.nolzo.event.dto.EventRecommendResponse;
 import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.entity.Event;
@@ -17,6 +19,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @ServiceTest
@@ -175,5 +179,119 @@ class EventServiceTest {
         Assertions.assertThat(result.get(0).getId()).isEqualTo(hamlet.getId());
         Assertions.assertThat(result.get(1).getId()).isEqualTo(cats.getId());
         Assertions.assertThat(result.get(0).getViewCount()).isGreaterThan(result.get(1).getViewCount());
+    }
+
+    @Test
+    void 추천_질의에서_지역과_카테고리를_해석해_조건에_맞는_공연을_추천한다() {
+        LocalDate weekendStart = LocalDate.now().with(java.time.DayOfWeek.SATURDAY);
+        eventService.save(추천용_이벤트_요청(
+                "서울 주말 뮤지컬",
+                "서울 공연장",
+                "데이트하기 좋은 뮤지컬 공연",
+                weekendStart,
+                weekendStart.plusDays(1),
+                EventCategory.MUSICAL
+        ), null);
+        eventService.save(추천용_이벤트_요청(
+                "부산 콘서트",
+                "부산 공연장",
+                "신나는 콘서트 공연",
+                weekendStart,
+                weekendStart.plusDays(1),
+                EventCategory.CONCERT
+        ), null);
+
+        EventRecommendResponse response = eventService.recommendEvents(
+                new EventRecommendRequest(null, "서울에서 뮤지컬 추천해줘")
+        );
+
+        Assertions.assertThat(response.condition().region()).isEqualTo("서울");
+        Assertions.assertThat(response.condition().category()).isEqualTo("MUSICAL");
+        Assertions.assertThat(response.recommendations())
+                .isNotEmpty()
+                .allSatisfy(item -> {
+                    Assertions.assertThat(item.venue()).contains("서울");
+                    Assertions.assertThat(item.category()).isEqualTo(EventCategory.MUSICAL);
+                    Assertions.assertThat(item.recommendationReason()).contains("서울");
+                });
+    }
+
+    @Test
+    void 추천_질의의_가격_상한보다_최저_좌석가가_비싸면_추천하지_않는다() {
+        LocalDate weekendStart = LocalDate.now().with(java.time.DayOfWeek.SATURDAY);
+        eventService.save(추천용_이벤트_요청(
+                "서울 가격 테스트 공연",
+                "서울 테스트홀",
+                "가격 조건 테스트용 공연",
+                weekendStart,
+                weekendStart.plusDays(1),
+                EventCategory.CONCERT
+        ), null);
+
+        EventRecommendResponse response = eventService.recommendEvents(
+                new EventRecommendRequest(null, "서울에서 7만원 이하 공연 추천해줘")
+        );
+
+        Assertions.assertThat(response.condition().maxPrice()).isEqualTo(70_000);
+        Assertions.assertThat(response.recommendations()).isEmpty();
+    }
+
+    @Test
+    void 이번_주말_조건이면_주말에_열리는_공연만_추천한다() {
+        LocalDate saturday = LocalDate.now().with(java.time.DayOfWeek.SATURDAY);
+        eventService.save(추천용_이벤트_요청(
+                "주말 공연",
+                "서울 아트홀",
+                "이번 주말에 열리는 공연",
+                saturday,
+                saturday.plusDays(1),
+                EventCategory.PLAY
+        ), null);
+        eventService.save(추천용_이벤트_요청(
+                "다음 주 공연",
+                "서울 아트홀",
+                "다음 주에 열리는 공연",
+                saturday.plusDays(3),
+                saturday.plusDays(4),
+                EventCategory.PLAY
+        ), null);
+
+        EventRecommendResponse response = eventService.recommendEvents(
+                new EventRecommendRequest(null, "이번 주말 공연 추천해줘")
+        );
+
+        Assertions.assertThat(response.condition().dateRange()).isEqualTo("이번 주말");
+        Assertions.assertThat(response.recommendations())
+                .extracting(item -> item.title())
+                .contains("주말 공연")
+                .doesNotContain("다음 주 공연");
+    }
+
+    private EventRequest 추천용_이벤트_요청(
+            String title,
+            String venue,
+            String description,
+            LocalDate startDate,
+            LocalDate endDate,
+            EventCategory category
+    ) {
+        return EventRequest.builder()
+                .title(title)
+                .venue(venue)
+                .description(description)
+                .startDate(startDate)
+                .endDate(endDate)
+                .eventCategory(category)
+                .runtime(120)
+                .ageLimit(12)
+                .schedules(List.of(
+                        new com.noljo.nolzo.schedule.dto.internal.ScheduleInfo(
+                                startDate,
+                                LocalTime.of(19, 0),
+                                LocalDateTime.now().minusDays(1),
+                                LocalDateTime.now().plusDays(30)
+                        )
+                ))
+                .build();
     }
 }

--- a/nolzo-api/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/nolzo-api/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -207,6 +207,7 @@ class EventServiceTest {
 
         Assertions.assertThat(response.condition().region()).isEqualTo("서울");
         Assertions.assertThat(response.condition().category()).isEqualTo("MUSICAL");
+        Assertions.assertThat(response.message()).isEqualTo("입력한 조건에 맞는 공연을 추천합니다.");
         Assertions.assertThat(response.recommendations())
                 .isNotEmpty()
                 .allSatisfy(item -> {
@@ -233,7 +234,11 @@ class EventServiceTest {
         );
 
         Assertions.assertThat(response.condition().maxPrice()).isEqualTo(70_000);
-        Assertions.assertThat(response.recommendations()).isEmpty();
+        Assertions.assertThat(response.message()).isEqualTo("입력한 조건과 정확히 일치하는 공연이 없어 인기 공연을 대신 추천합니다.");
+        Assertions.assertThat(response.recommendations()).isNotEmpty();
+        Assertions.assertThat(response.recommendations())
+                .allSatisfy(item ->
+                        Assertions.assertThat(item.recommendationReason()).contains("정확히 일치하는 공연이 없어"));
     }
 
     @Test
@@ -261,10 +266,35 @@ class EventServiceTest {
         );
 
         Assertions.assertThat(response.condition().dateRange()).isEqualTo("이번 주말");
+        Assertions.assertThat(response.message()).isEqualTo("입력한 조건에 맞는 공연을 추천합니다.");
         Assertions.assertThat(response.recommendations())
                 .extracting(item -> item.title())
                 .contains("주말 공연")
                 .doesNotContain("다음 주 공연");
+    }
+
+    @Test
+    void 조건에_맞는_공연이_없으면_인기_공연을_fallback으로_추천한다() {
+        LocalDate saturday = LocalDate.now().with(java.time.DayOfWeek.SATURDAY);
+        EventResponse popularEvent = eventService.save(추천용_이벤트_요청(
+                "인기 공연",
+                "서울 아트홀",
+                "많이 찾는 공연",
+                saturday,
+                saturday.plusDays(1),
+                EventCategory.CONCERT
+        ), null);
+        eventService.findById(popularEvent.getId());
+        eventService.findById(popularEvent.getId());
+
+        EventRecommendResponse response = eventService.recommendEvents(
+                new EventRecommendRequest(null, "광주에서 7만원 이하 연극 추천해줘")
+        );
+
+        Assertions.assertThat(response.message()).isEqualTo("입력한 조건과 정확히 일치하는 공연이 없어 인기 공연을 대신 추천합니다.");
+        Assertions.assertThat(response.recommendations()).isNotEmpty();
+        Assertions.assertThat(response.recommendations().get(0).recommendationReason())
+                .contains("정확히 일치하는 공연이 없어");
     }
 
     private EventRequest 추천용_이벤트_요청(

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/application/port/in/EventUseCase.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/application/port/in/EventUseCase.java
@@ -1,6 +1,8 @@
 package com.noljo.nolzo.event.application.port.in;
 
 import com.noljo.nolzo.event.dto.EventRequest;
+import com.noljo.nolzo.event.dto.EventRecommendRequest;
+import com.noljo.nolzo.event.dto.EventRecommendResponse;
 import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.entity.EventCategory;
@@ -27,4 +29,6 @@ public interface EventUseCase {
     List<EventResponse> getTop10ByCategory(EventCategory category);
 
     List<EventResponse> getTop6PopularEvents();
+
+    EventRecommendResponse recommendEvents(EventRecommendRequest request);
 }

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendCondition.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendCondition.java
@@ -1,0 +1,10 @@
+package com.noljo.nolzo.event.dto;
+
+public record EventRecommendCondition(
+        String region,
+        String dateRange,
+        Integer maxPrice,
+        String category,
+        String mood
+) {
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendItemResponse.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendItemResponse.java
@@ -1,0 +1,27 @@
+package com.noljo.nolzo.event.dto;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.entity.EventCategory;
+import java.time.LocalDate;
+
+public record EventRecommendItemResponse(
+        Long eventId,
+        String title,
+        String venue,
+        LocalDate startDate,
+        LocalDate endDate,
+        EventCategory category,
+        String recommendationReason
+) {
+    public static EventRecommendItemResponse of(Event event, String recommendationReason) {
+        return new EventRecommendItemResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getVenue(),
+                event.getStartDate(),
+                event.getEndDate(),
+                event.getEventCategory(),
+                recommendationReason
+        );
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendRequest.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendRequest.java
@@ -1,0 +1,10 @@
+package com.noljo.nolzo.event.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EventRecommendRequest(
+        Long memberId,
+        @NotBlank(message = "추천 질의는 비어 있을 수 없습니다.")
+        String query
+) {
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendResponse.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendResponse.java
@@ -4,14 +4,16 @@ import java.util.List;
 
 public record EventRecommendResponse(
         String originalQuery,
+        String message,
         EventRecommendCondition condition,
         List<EventRecommendItemResponse> recommendations
 ) {
     public static EventRecommendResponse of(
             String originalQuery,
+            String message,
             EventRecommendCondition condition,
             List<EventRecommendItemResponse> recommendations
     ) {
-        return new EventRecommendResponse(originalQuery, condition, recommendations);
+        return new EventRecommendResponse(originalQuery, message, condition, recommendations);
     }
 }

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendResponse.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/dto/EventRecommendResponse.java
@@ -1,0 +1,17 @@
+package com.noljo.nolzo.event.dto;
+
+import java.util.List;
+
+public record EventRecommendResponse(
+        String originalQuery,
+        EventRecommendCondition condition,
+        List<EventRecommendItemResponse> recommendations
+) {
+    public static EventRecommendResponse of(
+            String originalQuery,
+            EventRecommendCondition condition,
+            List<EventRecommendItemResponse> recommendations
+    ) {
+        return new EventRecommendResponse(originalQuery, condition, recommendations);
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendQueryInterpreter.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendQueryInterpreter.java
@@ -1,0 +1,95 @@
+package com.noljo.nolzo.event.service;
+
+import com.noljo.nolzo.event.dto.EventRecommendCondition;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventRecommendQueryInterpreter {
+
+    private static final Pattern MAX_PRICE_PATTERN = Pattern.compile("(\\d+)\\s*만원\\s*이하");
+
+    private static final Map<String, String> REGION_KEYWORDS = Map.of(
+            "서울", "서울",
+            "부산", "부산",
+            "대구", "대구",
+            "인천", "인천",
+            "광주", "광주",
+            "대전", "대전"
+    );
+
+    private static final Map<String, String> CATEGORY_KEYWORDS = Map.of(
+            "뮤지컬", "MUSICAL",
+            "콘서트", "CONCERT",
+            "연극", "PLAY"
+    );
+
+    private static final Map<String, String> MOOD_KEYWORDS = Map.of(
+            "데이트", "데이트",
+            "가족", "가족",
+            "혼자", "혼자"
+    );
+
+    public EventRecommendCondition interpret(String query) {
+        String normalizedQuery = query == null ? "" : query.trim();
+
+        return new EventRecommendCondition(
+                extractRegion(normalizedQuery),
+                extractDateRange(normalizedQuery),
+                extractMaxPrice(normalizedQuery),
+                extractCategory(normalizedQuery),
+                extractMood(normalizedQuery)
+        );
+    }
+
+    private String extractRegion(String query) {
+        return REGION_KEYWORDS.entrySet().stream()
+                .filter(entry -> query.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String extractDateRange(String query) {
+        if (query.contains("이번 주말")) {
+            return "이번 주말";
+        }
+
+        if (query.contains("이번 주")) {
+            return "이번 주";
+        }
+
+        if (query.contains("오늘")) {
+            return "오늘";
+        }
+
+        return null;
+    }
+
+    private Integer extractMaxPrice(String query) {
+        Matcher matcher = MAX_PRICE_PATTERN.matcher(query);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        return Integer.parseInt(matcher.group(1)) * 10_000;
+    }
+
+    private String extractCategory(String query) {
+        return CATEGORY_KEYWORDS.entrySet().stream()
+                .filter(entry -> query.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String extractMood(String query) {
+        return MOOD_KEYWORDS.entrySet().stream()
+                .filter(entry -> query.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendReasonGenerator.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendReasonGenerator.java
@@ -1,0 +1,71 @@
+package com.noljo.nolzo.event.service;
+
+import com.noljo.nolzo.event.dto.EventRecommendCondition;
+import com.noljo.nolzo.event.entity.Event;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventRecommendReasonGenerator {
+
+    public String generate(Event event, EventRecommendCondition condition, Integer minimumPrice) {
+        List<String> reasons = new ArrayList<>();
+
+        if (condition.region() != null && containsIgnoreCase(event.getVenue(), condition.region())) {
+            reasons.add(condition.region() + "에서 관람할 수 있는 공연입니다.");
+        }
+
+        if (condition.category() != null && condition.category().equals(event.getEventCategory().name())) {
+            reasons.add(toCategoryLabel(condition.category()) + " 장르를 찾는 조건과 잘 맞습니다.");
+        }
+
+        if (condition.dateRange() != null) {
+            reasons.add(condition.dateRange() + " 일정에 맞춰 관람할 수 있습니다.");
+        }
+
+        if (condition.maxPrice() != null && minimumPrice != null && minimumPrice <= condition.maxPrice()) {
+            reasons.add("최저 좌석가가 " + formatPrice(minimumPrice) + "부터라 예산 조건에 맞습니다.");
+        }
+
+        if (condition.mood() != null) {
+            reasons.add(toMoodReason(condition.mood()));
+        }
+
+        if (reasons.isEmpty()) {
+            reasons.add("현재 조건과 가까운 공연으로 추천합니다.");
+        }
+
+        return String.join(" ", reasons);
+    }
+
+    private String toCategoryLabel(String category) {
+        return switch (category) {
+            case "MUSICAL" -> "뮤지컬";
+            case "CONCERT" -> "콘서트";
+            case "PLAY" -> "연극";
+            default -> category;
+        };
+    }
+
+    private String toMoodReason(String mood) {
+        return switch (mood) {
+            case "데이트" -> "데이트 코스로 고려하기 좋은 분위기의 공연입니다.";
+            case "가족" -> "가족과 함께 관람하기 좋은 공연으로 추천합니다.";
+            case "혼자" -> "혼자 편하게 관람하기 좋은 공연으로 추천합니다.";
+            default -> mood + " 목적에 맞는 공연으로 추천합니다.";
+        };
+    }
+
+    private String formatPrice(int price) {
+        return String.format("%,d원", price);
+    }
+
+    private boolean containsIgnoreCase(String text, String keyword) {
+        if (text == null || keyword == null) {
+            return false;
+        }
+
+        return text.toLowerCase().contains(keyword.toLowerCase());
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendReasonGenerator.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendReasonGenerator.java
@@ -39,6 +39,10 @@ public class EventRecommendReasonGenerator {
         return String.join(" ", reasons);
     }
 
+    public String generateFallback(Event event) {
+        return "입력한 조건과 정확히 일치하는 공연이 없어 현재 인기 있거나 먼저 살펴볼 만한 공연으로 추천합니다.";
+    }
+
     private String toCategoryLabel(String category) {
         return switch (category) {
             case "MUSICAL" -> "뮤지컬";

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendService.java
@@ -41,8 +41,28 @@ public class EventRecommendService {
                 ))
                 .toList();
 
+        if (recommendations.isEmpty() && hasSearchCondition(condition)) {
+            List<EventRecommendItemResponse> fallbackRecommendations = eventPersistencePort.findTop6ByOrderByViewCountDesc().stream()
+                    .limit(5)
+                    .map(event -> EventRecommendItemResponse.of(
+                            event,
+                            eventRecommendReasonGenerator.generateFallback(event)
+                    ))
+                    .toList();
+
+            return EventRecommendResponse.of(
+                    request.query(),
+                    "입력한 조건과 정확히 일치하는 공연이 없어 인기 공연을 대신 추천합니다.",
+                    condition,
+                    fallbackRecommendations
+            );
+        }
+
         return EventRecommendResponse.of(
                 request.query(),
+                recommendations.isEmpty()
+                        ? "현재 추천할 수 있는 공연이 없습니다."
+                        : "입력한 조건에 맞는 공연을 추천합니다.",
                 condition,
                 recommendations
         );

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventRecommendService.java
@@ -1,0 +1,183 @@
+package com.noljo.nolzo.event.service;
+
+import com.noljo.nolzo.event.application.port.out.EventPersistencePort;
+import com.noljo.nolzo.event.dto.EventRecommendCondition;
+import com.noljo.nolzo.event.dto.EventRecommendItemResponse;
+import com.noljo.nolzo.event.dto.EventRecommendRequest;
+import com.noljo.nolzo.event.dto.EventRecommendResponse;
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.schedule.entity.Schedule;
+import com.noljo.nolzo.seat.entity.Seat;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalInt;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EventRecommendService {
+
+    private final EventPersistencePort eventPersistencePort;
+    private final EventRecommendQueryInterpreter eventRecommendQueryInterpreter;
+    private final EventRecommendReasonGenerator eventRecommendReasonGenerator;
+
+    @Transactional(readOnly = true)
+    public EventRecommendResponse recommend(EventRecommendRequest request) {
+        EventRecommendCondition condition = eventRecommendQueryInterpreter.interpret(request.query());
+        List<EventRecommendItemResponse> recommendations = findRecommendationCandidates(condition).stream()
+                .limit(5)
+                .map(candidate -> EventRecommendItemResponse.of(
+                        candidate.event(),
+                        eventRecommendReasonGenerator.generate(
+                                candidate.event(),
+                                condition,
+                                candidate.minimumPrice()
+                        )
+                ))
+                .toList();
+
+        return EventRecommendResponse.of(
+                request.query(),
+                condition,
+                recommendations
+        );
+    }
+
+    private List<EventRecommendationCandidate> findRecommendationCandidates(EventRecommendCondition condition) {
+        List<Event> events = hasSearchCondition(condition)
+                ? eventPersistencePort.findAll()
+                : eventPersistencePort.findTop6ByOrderByViewCountDesc();
+
+        return events.stream()
+                .map(event -> new EventRecommendationCandidate(event, getMinimumSeatPrice(event)))
+                .filter(candidate -> matches(candidate, condition))
+                .sorted(Comparator
+                        .comparingInt((EventRecommendationCandidate candidate) -> calculateScore(candidate, condition))
+                        .reversed()
+                        .thenComparing(Comparator.comparingLong(
+                                (EventRecommendationCandidate candidate) -> candidate.event().getViewCount()
+                        ).reversed())
+                        .thenComparing(
+                                candidate -> candidate.event().getStartDate(),
+                                Comparator.nullsLast(Comparator.naturalOrder())
+                        ))
+                .toList();
+    }
+
+    private boolean hasSearchCondition(EventRecommendCondition condition) {
+        return condition.region() != null
+                || condition.dateRange() != null
+                || condition.maxPrice() != null
+                || condition.category() != null
+                || condition.mood() != null;
+    }
+
+    private boolean matches(EventRecommendationCandidate candidate, EventRecommendCondition condition) {
+        Event event = candidate.event();
+
+        if (condition.region() != null && !containsIgnoreCase(event.getVenue(), condition.region())) {
+            return false;
+        }
+
+        if (condition.category() != null && !condition.category().equals(event.getEventCategory().name())) {
+            return false;
+        }
+
+        if (condition.dateRange() != null && !matchesDateRange(event, condition.dateRange())) {
+            return false;
+        }
+
+        if (condition.maxPrice() != null) {
+            return candidate.minimumPrice() != null && candidate.minimumPrice() <= condition.maxPrice();
+        }
+
+        return true;
+    }
+
+    private boolean matchesDateRange(Event event, String dateRange) {
+        LocalDate today = LocalDate.now();
+
+        return switch (dateRange) {
+            case "오늘" -> overlaps(event, today, today);
+            case "이번 주" -> overlaps(
+                    event,
+                    today.with(DayOfWeek.MONDAY),
+                    today.with(DayOfWeek.SUNDAY)
+            );
+            case "이번 주말" -> overlaps(
+                    event,
+                    today.with(DayOfWeek.SATURDAY),
+                    today.with(DayOfWeek.SUNDAY)
+            );
+            default -> true;
+        };
+    }
+
+    private boolean overlaps(Event event, LocalDate from, LocalDate to) {
+        if (event.getStartDate() == null || event.getEndDate() == null) {
+            return false;
+        }
+
+        return !event.getEndDate().isBefore(from) && !event.getStartDate().isAfter(to);
+    }
+
+    private Integer getMinimumSeatPrice(Event event) {
+        OptionalInt minimumPrice = event.getSchedules().stream()
+                .filter(Objects::nonNull)
+                .map(Schedule::getSeats)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .mapToInt(Seat::getPrice)
+                .min();
+
+        return minimumPrice.isPresent() ? minimumPrice.getAsInt() : null;
+    }
+
+    private int calculateScore(EventRecommendationCandidate candidate, EventRecommendCondition condition) {
+        Event event = candidate.event();
+        int score = 0;
+
+        if (condition.region() != null && containsIgnoreCase(event.getVenue(), condition.region())) {
+            score += 3;
+        }
+
+        if (condition.category() != null && condition.category().equals(event.getEventCategory().name())) {
+            score += 3;
+        }
+
+        if (condition.dateRange() != null && matchesDateRange(event, condition.dateRange())) {
+            score += 2;
+        }
+
+        if (condition.maxPrice() != null && candidate.minimumPrice() != null
+                && candidate.minimumPrice() <= condition.maxPrice()) {
+            score += 2;
+        }
+
+        if (condition.mood() != null) {
+            score += 1;
+        }
+
+        if (!hasSearchCondition(condition)) {
+            score += 1;
+        }
+
+        return score;
+    }
+
+    private boolean containsIgnoreCase(String text, String keyword) {
+        if (text == null || keyword == null) {
+            return false;
+        }
+
+        return text.toLowerCase().contains(keyword.toLowerCase());
+    }
+
+    private record EventRecommendationCandidate(Event event, Integer minimumPrice) {
+    }
+}

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -2,7 +2,6 @@ package com.noljo.nolzo.event.service;
 
 import com.noljo.nolzo.event.application.port.in.EventUseCase;
 import com.noljo.nolzo.event.application.port.out.EventImageUploadPort;
-import com.noljo.nolzo.event.dto.EventRecommendCondition;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventRecommendRequest;
 import com.noljo.nolzo.event.dto.EventRecommendResponse;
@@ -38,7 +37,7 @@ public class EventService implements EventUseCase {
     private final EventPersistencePort eventPersistencePort;
     private final SeatUseCase seatUseCase;
     private final EventImageUploadPort eventImageUploadPort;
-    private final EventRecommendQueryInterpreter eventRecommendQueryInterpreter;
+    private final EventRecommendService eventRecommendService;
     private final EntityManager em;
 
     @Transactional(readOnly = true)
@@ -151,12 +150,6 @@ public class EventService implements EventUseCase {
 
     @Transactional(readOnly = true)
     public EventRecommendResponse recommendEvents(EventRecommendRequest request) {
-        EventRecommendCondition condition = eventRecommendQueryInterpreter.interpret(request.query());
-
-        return EventRecommendResponse.of(
-                request.query(),
-                condition,
-                List.of()
-        );
+        return eventRecommendService.recommend(request);
     }
 }

--- a/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/nolzo-core/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -2,7 +2,10 @@ package com.noljo.nolzo.event.service;
 
 import com.noljo.nolzo.event.application.port.in.EventUseCase;
 import com.noljo.nolzo.event.application.port.out.EventImageUploadPort;
+import com.noljo.nolzo.event.dto.EventRecommendCondition;
 import com.noljo.nolzo.event.dto.EventRequest;
+import com.noljo.nolzo.event.dto.EventRecommendRequest;
+import com.noljo.nolzo.event.dto.EventRecommendResponse;
 import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.entity.Event;
@@ -35,6 +38,7 @@ public class EventService implements EventUseCase {
     private final EventPersistencePort eventPersistencePort;
     private final SeatUseCase seatUseCase;
     private final EventImageUploadPort eventImageUploadPort;
+    private final EventRecommendQueryInterpreter eventRecommendQueryInterpreter;
     private final EntityManager em;
 
     @Transactional(readOnly = true)
@@ -143,5 +147,16 @@ public class EventService implements EventUseCase {
         return popularEvents.stream()
                 .map(EventResponse::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public EventRecommendResponse recommendEvents(EventRecommendRequest request) {
+        EventRecommendCondition condition = eventRecommendQueryInterpreter.interpret(request.query());
+
+        return EventRecommendResponse.of(
+                request.query(),
+                condition,
+                List.of()
+        );
     }
 }


### PR DESCRIPTION
## 📌 개요

* 자연어 질의를 기반으로 조건에 맞는 공연을 추천해주는 `사용자 맞춤 공연 탐색 도우미 API` 1차 버전을 추가했습니다.
* 1차 단계에서는 AI/RAG를 바로 붙이지 않고, 자연어 질의를 규칙 기반으로 해석해 지역·기간·가격·카테고리·분위기 조건을 추출하고, 조건에 맞는 공연 후보와 추천 사유를 반환하는 흐름을 먼저 구현했습니다.
* 또한 추천 결과가 없을 때는 인기 공연을 fallback으로 제안하도록 해, 빈 응답보다 자연스러운 탐색 경험을 제공할 수 있도록 보완했습니다.

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#35`)

### 자연어 질의 해석 로직 추가

* 자연어 질의를 바로 DB 조회에 사용하지 않고, 먼저 추천 조건으로 해석하는 로직을 추가했습니다.
* 1차에서 해석하는 조건은 다음과 같습니다.
  - 지역
  - 기간 (`오늘`, `이번 주`, `이번 주말`)
  - 가격 상한 (`10만원 이하` 형태)
  - 카테고리 (`뮤지컬`, `콘서트`, `연극`)
  - 분위기 (`데이트`, `가족`, `혼자`)
* 이를 통해 사용자의 질의를 내부적으로 구조화된 추천 조건으로 변환한 뒤 후속 추천 로직에서 활용할 수 있도록 했습니다.

### 추천 전용 서비스 분리

* 추천 로직이 이벤트 CRUD 서비스에 과도하게 섞이지 않도록 `EventRecommendService`를 추가해 추천 전용 흐름을 분리했습니다.
* `EventService`는 추천 요청을 추천 전용 서비스에 위임하는 형태로 정리했습니다.
* 이를 통해:
  - 기존 이벤트 관리 로직과 추천 로직의 책임을 분리하고
  - 이후 AI/RAG 확장 시 교체 포인트를 명확히 할 수 있도록 구성했습니다.

### 조건 기반 후보군 조회 및 추천 로직 추가

* 현재 `Event`와 `Schedule`, `Seat` 데이터로 바로 활용 가능한 조건 기반 추천 로직을 추가했습니다.
* 추천 시 다음 조건을 기준으로 공연 후보를 선별합니다.
  - venue 기반 지역 매칭
  - 공연 카테고리 매칭
  - 이벤트 기간과 질의 기간의 겹침 여부
  - 좌석 최소 가격과 가격 상한 비교
* 가격 조건은 이벤트 자체 필드가 아닌, 연결된 좌석의 최저 가격을 계산해 반영하도록 구성했습니다.

### 추천 이유 생성 추가

* 각 추천 결과에는 왜 추천되었는지 알 수 있도록 규칙 기반 추천 사유를 함께 생성합니다.
* 예를 들어:
  - 지역이 일치하는 경우
  - 장르가 일치하는 경우
  - 기간 조건에 맞는 경우
  - 가격 조건에 맞는 경우
  - 분위기 목적에 맞는 경우
  등을 조합해 추천 사유를 생성하도록 했습니다.

### fallback 정책 추가

* 조건에 정확히 일치하는 공연이 없을 경우 빈 결과만 내려주지 않도록 fallback 정책을 추가했습니다.
* 이 경우:
  - 안내 메시지로 조건 미일치 상황을 전달하고
  - 인기 공연을 대신 추천하도록 구성했습니다.
* 이를 통해 추천 API가 항상 일정 수준의 탐색 경험을 제공할 수 있도록 보완했습니다.

## 📌 차후 계획 (Optional)

* 추천 API의 컨트롤러/API 테스트 추가
* Swagger 또는 문서 예시 보강
* AI/LLM 기반 질의 해석 고도화
* RAG/벡터 검색 기반 추천 후보군 확장
* 사용자 예매/찜/알림 구독 이력 기반 개인화 추천

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

close: #35 
